### PR TITLE
fix: post- and pre-steps are now detected as used

### DIFF
--- a/pkg/parser/validate/commands.go
+++ b/pkg/parser/validate/commands.go
@@ -25,9 +25,21 @@ func (val Validate) checkIfCommandIsUsed(command ast.Command) bool {
 			return true
 		}
 	}
+
 	for _, job := range val.Doc.Jobs {
 		if val.checkIfStepsContainStep(job.Steps, command.Name) {
 			return true
+		}
+	}
+
+	for _, workflow := range val.Doc.Workflows {
+		for _, jobRef := range workflow.JobRefs {
+			steps := jobRef.PostSteps
+			steps = append(steps, jobRef.PreSteps...)
+
+			if val.checkIfStepsContainStep(steps, command.Name) {
+				return true
+			}
 		}
 	}
 


### PR DESCRIPTION
When a commend is used only in pre-steps or post-steps, it is marked as unused with a warning diagnostic.
Fixed this issue.

CCI docs on pre- & post-steps: https://circleci.com/docs/configuration-reference/#pre-steps-and-post-steps