### PR TITLE
Fix/orb caching issue

### DIFF
--- a/e2e/__snapshots__/diagnostic.test.ts.snap
+++ b/e2e/__snapshots__/diagnostic.test.ts.snap
@@ -1,30 +1,105 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Diagnostic testing files diagnostic.yml 1`] = `
+exports[`Diagnostic testing files autocomplete-jobs.yml 1`] = `
 DiagnosticList {
   "list": [
     {
-      "data": [],
-      "message": "Cannot find declaration for step slack/notify",
+      "message": "You may want to add the \`store_test_results\` step to visualize the test results in CircleCI",
       "range": {
         "end": {
-          "character": 20,
+          "character": 7,
+          "line": 63,
+        },
+        "start": {
+          "character": 2,
+          "line": 63,
+        },
+      },
+      "severity": 4,
+    },
+    {
+      "data": [],
+      "message": "Job is unused",
+      "range": {
+        "end": {
+          "character": 14,
+          "line": 48,
+        },
+        "start": {
+          "character": 6,
+          "line": 48,
+        },
+      },
+      "severity": 2,
+      "source": "cci-language-server",
+    },
+    {
+      "data": [],
+      "message": "Job is unused",
+      "range": {
+        "end": {
+          "character": 13,
           "line": 24,
         },
         "start": {
-          "character": 8,
+          "character": 6,
           "line": 24,
+        },
+      },
+      "severity": 2,
+      "source": "cci-language-server",
+    },
+    {
+      "data": [],
+      "message": "Orb is unused",
+      "range": {
+        "end": {
+          "character": 27,
+          "line": 9,
+        },
+        "start": {
+          "character": 2,
+          "line": 9,
+        },
+      },
+      "severity": 2,
+      "source": "cci-language-server",
+    },
+    {
+      "data": [],
+      "message": "version must be one of the following: 2, 2.1",
+      "range": {
+        "end": {
+          "character": 14,
+          "line": 0,
+        },
+        "start": {
+          "character": 0,
+          "line": 0,
         },
       },
       "severity": 1,
       "source": "cci-language-server",
     },
+  ],
+}
+`;
+
+exports[`Diagnostic testing files config1.yml 1`] = `
+DiagnosticList {
+  "list": [],
+}
+`;
+
+exports[`Diagnostic testing files diagnostic.yml 1`] = `
+DiagnosticList {
+  "list": [
     {
       "data": [
         {
           "edit": {
             "changes": {
-              "file:///home/abraham/projects/yaml-language-server/test-files/.circleci/diagnostic.yml": [
+              "file:///home/circleci/project/test-files/.circleci/diagnostic.yml": [
                 {
                   "newText": "4.12.0",
                   "range": {
@@ -47,7 +122,7 @@ DiagnosticList {
         {
           "edit": {
             "changes": {
-              "file:///home/abraham/projects/yaml-language-server/test-files/.circleci/diagnostic.yml": [
+              "file:///home/circleci/project/test-files/.circleci/diagnostic.yml": [
                 {
                   "newText": "4.12.0",
                   "range": {

--- a/e2e/diagnostic.test.ts
+++ b/e2e/diagnostic.test.ts
@@ -15,7 +15,7 @@ describe('Diagnostic testing files', () => {
     expect(diagnostics).toMatchSnapshot();
   });
 
-  it.only('diagnostic.yml', async () => {
+  it('diagnostic.yml', async () => {
     const testingFile = 'diagnostic.yml';
     const diagnostics = await commands.didOpen(testingFile);
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "lint:e2e": "eslint e2e/",
-    "test:e2e": "jest diagnostic",
+    "test:e2e": "jest",
     "test:e2e:ci": "jest --maxWorkers 1"
   },
   "author": "",

--- a/pkg/parser/orbs.go
+++ b/pkg/parser/orbs.go
@@ -9,6 +9,22 @@ import (
 	"go.lsp.dev/protocol"
 )
 
+func (doc *YamlDocument) GetOrbInfoFromName(name string, cache *utils.Cache) (*ast.OrbInfo, error) {
+	// Searching within local orbs
+	orbInfo, ok := doc.LocalOrbInfo[name]
+	if ok {
+		return orbInfo, nil
+	}
+
+	orb, ok := doc.Orbs[name]
+
+	if !ok {
+		return nil, nil
+	}
+
+	return doc.GetOrFetchOrbInfo(orb, cache)
+}
+
 func (doc *YamlDocument) GetOrFetchOrbInfo(orb ast.Orb, cache *utils.Cache) (*ast.OrbInfo, error) {
 	// Searching within local orbs
 	orbInfo, ok := doc.LocalOrbInfo[orb.Name]

--- a/pkg/parser/yamlparser.go
+++ b/pkg/parser/yamlparser.go
@@ -242,9 +242,9 @@ func (doc *YamlDocument) IsOrbCommand(orbCommand string, cache *utils.Cache) boo
 	orbName := splittedCommand[0]
 	commandName := splittedCommand[1]
 
-	orbInfo := doc.GetOrbInfo(cache, orbName)
+	orbInfo, err := doc.GetOrbInfoFromName(orbName, cache)
 
-	if orbInfo == nil {
+	if err != nil || orbInfo == nil {
 		return false
 	}
 
@@ -502,20 +502,4 @@ func (doc *YamlDocument) GetDefinedParams(entityName string) map[string]ast.Para
 	}
 
 	return definedParams
-}
-
-func (doc *YamlDocument) GetOrbInfo(cache *utils.Cache, name string) *ast.OrbInfo {
-	orb, ok := doc.Orbs[name]
-
-	if !ok {
-		return nil
-	}
-
-	if orb.Url.IsLocal {
-		return doc.LocalOrbInfo[name]
-	}
-
-	orbId := orb.Url.GetOrbID()
-
-	return cache.OrbCache.GetOrb(orbId)
 }

--- a/pkg/services/complete/complete.go
+++ b/pkg/services/complete/complete.go
@@ -96,5 +96,6 @@ func (ch *CompletionHandler) addCompletionItemFieldWithCustomText(label string, 
 }
 
 func (ch *CompletionHandler) GetOrbInfo(orb ast.Orb) *ast.OrbInfo {
-	return ch.Doc.GetOrbInfo(ch.Cache, orb.Name)
+	orbInfo, _ := ch.Doc.GetOrFetchOrbInfo(orb, ch.Cache)
+	return orbInfo
 }

--- a/pkg/services/definition/definition.go
+++ b/pkg/services/definition/definition.go
@@ -51,6 +51,6 @@ func (def DefinitionStruct) Definition(yamlDocument yamlparser.YamlDocument) ([]
 	return nil, nil
 }
 
-func (def DefinitionStruct) GetOrbInfo(name string) *ast.OrbInfo {
-	return def.Doc.GetOrbInfo(def.Cache, name)
+func (def DefinitionStruct) GetOrbInfo(name string) (*ast.OrbInfo, error) {
+	return def.Doc.GetOrbInfoFromName(name, def.Cache)
 }

--- a/pkg/services/definition/orb.go
+++ b/pkg/services/definition/orb.go
@@ -18,16 +18,22 @@ func (def DefinitionStruct) getOrbDefinition() ([]protocol.Location, error) {
 		}
 	}
 
-	if orb := def.GetOrbInfo(orb.Name); orb != nil {
-		return []protocol.Location{
-			{
-				URI:   uri.New(orb.RemoteInfo.FilePath),
-				Range: protocol.Range{},
-			},
-		}, nil
+	orbInfo, err := def.GetOrbInfo(orb.Name)
+
+	if err != nil {
+		return nil, err
 	}
 
-	return []protocol.Location{}, nil
+	if orbInfo == nil {
+		return []protocol.Location{}, nil
+	}
+
+	return []protocol.Location{
+		{
+			URI:   uri.New(orbInfo.RemoteInfo.FilePath),
+			Range: protocol.Range{},
+		},
+	}, nil
 }
 
 func (def DefinitionStruct) getOrbLocation(name string, redirectToOrbFile bool) ([]protocol.Location, error) {
@@ -36,7 +42,12 @@ func (def DefinitionStruct) getOrbLocation(name string, redirectToOrbFile bool) 
 		if orb, ok := def.Doc.Orbs[splittedName[0]]; ok {
 
 			if redirectToOrbFile {
-				orbFile := def.GetOrbInfo(orb.Name)
+				orbFile, err := def.GetOrbInfo(orb.Name)
+
+				if err != nil {
+					return nil, err
+				}
+
 				return def.getOrbCommandOrJobLocation(orbFile, splittedName[1])
 			}
 
@@ -90,7 +101,12 @@ func (def DefinitionStruct) getOrbParamLocation(name string, paramName string) (
 		return []protocol.Location{}, fmt.Errorf("orb not found")
 	}
 
-	orbFile := def.GetOrbInfo(name)
+	orbFile, err := def.GetOrbInfo(name)
+
+	if err != nil {
+		return []protocol.Location{}, err
+	}
+
 	if orbFile == nil {
 		return []protocol.Location{}, fmt.Errorf("orb not found")
 	}

--- a/pkg/services/hover/job.go
+++ b/pkg/services/hover/job.go
@@ -57,7 +57,7 @@ func hoverSteps(doc yamlparser.YamlDocument, path []string, cache *utils.Cache) 
 func hoverOrb(doc yamlparser.YamlDocument, stepName string, cache *utils.Cache) string {
 	splittedStep := strings.Split(stepName, "/")
 	orbInDoc := doc.Orbs[splittedStep[0]]
-	orb := doc.GetOrbInfo(cache, orbInDoc.Name)
+	orb, _ := doc.GetOrFetchOrbInfo(orbInDoc, cache)
 	if orb == nil {
 		return ""
 	}

--- a/pkg/services/hover/orbs.go
+++ b/pkg/services/hover/orbs.go
@@ -20,9 +20,11 @@ func HoverInOrbs(doc yamlparser.YamlDocument, path []string, cache *utils.Cache)
 
 func orbDefinition(doc yamlparser.YamlDocument, orbName string, cache *utils.Cache) string {
 	orbInDoc := doc.Orbs[orbName]
-	orb := doc.GetOrbInfo(cache, orbInDoc.Name)
-	if orb != nil {
-		return orb.Description
+	orb, err := doc.GetOrbInfoFromName(orbInDoc.Name, cache)
+
+	if err != nil || orb == nil {
+		return ""
 	}
-	return ""
+
+	return orb.Description
 }


### PR DESCRIPTION
Fix a bug due to [DEVEX-506](https://circleci.atlassian.net/browse/DEVEX-506): when opening a file, the remote orbs will be marked as they are not found. This is because the function used to resolve the orb didn't try to fetch it is not in the cache.

[DEVEX-506]: https://circleci.atlassian.net/browse/DEVEX-506?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DEVEX-506]: https://circleci.atlassian.net/browse/DEVEX-506?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ