### PR TITLE
fix: Allow aws_auth to be given with oidc_role_arn

### DIFF
--- a/pkg/services/testdata/noErrors.yml
+++ b/pkg/services/testdata/noErrors.yml
@@ -59,6 +59,14 @@ jobs:
       - shellcheck/check:
           dir: ./.circleci/scripts/
 
+  jobWithAWS_OIDC:
+    docker:
+      - image: node:latest
+        aws_auth:
+          oidc_role_arn: role
+    steps:
+      - run: echo "Hello"
+
 workflows:
   test-build:
     jobs:
@@ -91,3 +99,4 @@ workflows:
       - shellcheck/check:
           name: shellcheck
           dir: ./.circleci/scripts/
+      - jobWithAWS_OIDC

--- a/schema.json
+++ b/schema.json
@@ -140,20 +140,36 @@
 															]
 														},
 														"aws_auth": {
-															"type": "object",
-															"properties": {
-																"aws_access_key_id": {
-																	"type": "string"
+															"oneOf": [
+																{
+																	"type": "object",
+																	"properties": {
+																		"aws_access_key_id": {
+																			"type": "string"
+																		},
+																		"aws_secret_access_key": {
+																			"type": "string"
+																		}
+																	},
+																	"required": [
+																		"aws_access_key_id",
+																		"aws_secret_access_key"
+																	],
+																	"additionalProperties": false
 																},
-																"aws_secret_access_key": {
-																	"type": "string"
+																{
+																	"type": "object",
+																	"properties": {
+																		"oidc_role_arn": {
+																			"type": "string"
+																		}
+																	},
+																	"required": [
+																		"oidc_role_arn"
+																	],
+																	"additionalProperties": false
 																}
-															},
-															"required": [
-																"aws_access_key_id",
-																"aws_secret_access_key"
-															],
-															"additionalProperties": false
+															]
 														},
 														"auth": {
 															"type": "object",
@@ -602,20 +618,36 @@
 															]
 														},
 														"aws_auth": {
-															"type": "object",
-															"properties": {
-																"aws_access_key_id": {
-																	"type": "string"
+															"oneOf": [
+																{
+																	"type": "object",
+																	"properties": {
+																		"aws_access_key_id": {
+																			"type": "string"
+																		},
+																		"aws_secret_access_key": {
+																			"type": "string"
+																		}
+																	},
+																	"required": [
+																		"aws_access_key_id",
+																		"aws_secret_access_key"
+																	],
+																	"additionalProperties": false
 																},
-																"aws_secret_access_key": {
-																	"type": "string"
+																{
+																	"type": "object",
+																	"properties": {
+																		"oidc_role_arn": {
+																			"type": "string"
+																		}
+																	},
+																	"required": [
+																		"oidc_role_arn"
+																	],
+																	"additionalProperties": false
 																}
-															},
-															"required": [
-																"aws_access_key_id",
-																"aws_secret_access_key"
-															],
-															"additionalProperties": false
+															]
 														},
 														"auth": {
 															"type": "object",
@@ -1124,20 +1156,36 @@
 											]
 										},
 										"aws_auth": {
-											"type": "object",
-											"properties": {
-												"aws_access_key_id": {
-													"type": "string"
+											"oneOf": [
+												{
+													"type": "object",
+													"properties": {
+														"aws_access_key_id": {
+															"type": "string"
+														},
+														"aws_secret_access_key": {
+															"type": "string"
+														}
+													},
+													"required": [
+														"aws_access_key_id",
+														"aws_secret_access_key"
+													],
+													"additionalProperties": false
 												},
-												"aws_secret_access_key": {
-													"type": "string"
+												{
+													"type": "object",
+													"properties": {
+														"oidc_role_arn": {
+															"type": "string"
+														}
+													},
+													"required": [
+														"oidc_role_arn"
+													],
+													"additionalProperties": false
 												}
-											},
-											"required": [
-												"aws_access_key_id",
-												"aws_secret_access_key"
-											],
-											"additionalProperties": false
+											]
 										},
 										"auth": {
 											"type": "object",
@@ -1748,20 +1796,36 @@
 											]
 										},
 										"aws_auth": {
-											"type": "object",
-											"properties": {
-												"aws_access_key_id": {
-													"type": "string"
+											"oneOf": [
+												{
+													"type": "object",
+													"properties": {
+														"aws_access_key_id": {
+															"type": "string"
+														},
+														"aws_secret_access_key": {
+															"type": "string"
+														}
+													},
+													"required": [
+														"aws_access_key_id",
+														"aws_secret_access_key"
+													],
+													"additionalProperties": false
 												},
-												"aws_secret_access_key": {
-													"type": "string"
+												{
+													"type": "object",
+													"properties": {
+														"oidc_role_arn": {
+															"type": "string"
+														}
+													},
+													"required": [
+														"oidc_role_arn"
+													],
+													"additionalProperties": false
 												}
-											},
-											"required": [
-												"aws_access_key_id",
-												"aws_secret_access_key"
-											],
-											"additionalProperties": false
+											]
 										},
 										"auth": {
 											"type": "object",
@@ -2157,20 +2221,36 @@
 																]
 															},
 															"aws_auth": {
-																"type": "object",
-																"properties": {
-																	"aws_access_key_id": {
-																		"type": "string"
+																"oneOf": [
+																	{
+																		"type": "object",
+																		"properties": {
+																			"aws_access_key_id": {
+																				"type": "string"
+																			},
+																			"aws_secret_access_key": {
+																				"type": "string"
+																			}
+																		},
+																		"required": [
+																			"aws_access_key_id",
+																			"aws_secret_access_key"
+																		],
+																		"additionalProperties": false
 																	},
-																	"aws_secret_access_key": {
-																		"type": "string"
+																	{
+																		"type": "object",
+																		"properties": {
+																			"oidc_role_arn": {
+																				"type": "string"
+																			}
+																		},
+																		"required": [
+																			"oidc_role_arn"
+																		],
+																		"additionalProperties": false
 																	}
-																},
-																"required": [
-																	"aws_access_key_id",
-																	"aws_secret_access_key"
-																],
-																"additionalProperties": false
+																]
 															},
 															"auth": {
 																"type": "object",
@@ -2625,20 +2705,36 @@
 																]
 															},
 															"aws_auth": {
-																"type": "object",
-																"properties": {
-																	"aws_access_key_id": {
-																		"type": "string"
+																"oneOf": [
+																	{
+																		"type": "object",
+																		"properties": {
+																			"aws_access_key_id": {
+																				"type": "string"
+																			},
+																			"aws_secret_access_key": {
+																				"type": "string"
+																			}
+																		},
+																		"required": [
+																			"aws_access_key_id",
+																			"aws_secret_access_key"
+																		],
+																		"additionalProperties": false
 																	},
-																	"aws_secret_access_key": {
-																		"type": "string"
+																	{
+																		"type": "object",
+																		"properties": {
+																			"oidc_role_arn": {
+																				"type": "string"
+																			}
+																		},
+																		"required": [
+																			"oidc_role_arn"
+																		],
+																		"additionalProperties": false
 																	}
-																},
-																"required": [
-																	"aws_access_key_id",
-																	"aws_secret_access_key"
-																],
-																"additionalProperties": false
+																]
 															},
 															"auth": {
 																"type": "object",


### PR DESCRIPTION
Allowing OIDC authentication for docker `aws_auth`
This just needed to be put in the validation `schema.json`
https://circleci.atlassian.net/browse/DEVEX-1092