### PR TITLE
fix: change diagnostic location for param executor default value

### DIFF
--- a/pkg/parser/validate/jobs.go
+++ b/pkg/parser/validate/jobs.go
@@ -58,11 +58,9 @@ func (val Validate) validateSingleJob(job ast.Job) {
 			if param != nil {
 				switch param := param.(type) {
 				case ast.StringParameter:
-					checkParam(param.Default, param.DefaultRange)
 				case ast.ExecutorParameter:
-					checkParam(param.Default, param.DefaultRange)
+					checkParam(param.Default, job.ExecutorRange)
 				}
-
 			}
 
 		} else if !val.Doc.DoesExecutorExist(job.Executor) {

--- a/pkg/parser/validate/jobs_test.go
+++ b/pkg/parser/validate/jobs_test.go
@@ -1,0 +1,57 @@
+package validate
+
+import (
+	"testing"
+
+	"github.com/CircleCI-Public/circleci-yaml-language-server/pkg/parser"
+	"github.com/CircleCI-Public/circleci-yaml-language-server/pkg/utils"
+	"github.com/stretchr/testify/assert"
+	"go.lsp.dev/protocol"
+	"go.lsp.dev/uri"
+)
+
+func TestExecutorParam(t *testing.T) {
+	yamlData := `jobs:
+  test:
+    parameters:
+      os:
+        type: executor
+    executor: << parameters.os >>
+    steps:
+      - checkout`
+	ctx := &utils.LsContext{
+		Api: utils.ApiContext{
+			Token:   "XXXXXXXXXXXX",
+			HostUrl: "https://circleci.com",
+		},
+	}
+	doc, err := parser.ParseFromContent(
+		[]byte(yamlData),
+		ctx,
+		uri.URI(""),
+		protocol.Position{},
+	)
+	assert.NoError(t, err, "invalid YAML data")
+	assert.Contains(t, doc.Jobs, "test")
+
+	val := Validate{
+		Context:     ctx,
+		Doc:         doc,
+		Diagnostics: &[]protocol.Diagnostic{},
+	}
+	val.validateSingleJob(doc.Jobs["test"])
+
+	expectedDiag := protocol.Diagnostic{
+		Range: protocol.Range{
+			Start: protocol.Position{Line: 5, Character: 4},
+			End:   protocol.Position{Line: 5, Character: 33},
+		},
+		Severity: protocol.DiagnosticSeverityError,
+	}
+	for _, diag := range *val.Diagnostics {
+		if diag.Range == expectedDiag.Range && diag.Severity == expectedDiag.Severity {
+			return
+		}
+	}
+	t.Fatalf(`missing "parameter as executor" diagnostic`)
+}


### PR DESCRIPTION
This PR fixes the range reported for a diagnostic, when a job executor was specified using a parameter, and the parameter's default value did not resolve to an actual job name.

The original code passed a default range instead of the actual executor range to the job checking function.

Before:
<img width="559" alt="Screenshot 2023-06-02 at 15 28 15" src="https://github.com/CircleCI-Public/circleci-yaml-language-server/assets/731497/7c95a832-e896-417d-b28f-5db2fcf8d8d3">

After:
<img width="555" alt="Screenshot 2023-06-02 at 15 27 38" src="https://github.com/CircleCI-Public/circleci-yaml-language-server/assets/731497/4db1bbb9-53a9-4789-9e85-5b6fd292d2ab">

