### PR TITLE
chore: "attach to process" in VS Code looks for start_server

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -102,7 +102,7 @@
       "type": "go",
       "request": "attach",
       "mode": "local",
-      "processId": 0
+      "processId": "start_server"
     }
   ]
 }


### PR DESCRIPTION
This PR changes the way the "Attach to Process" debug session is launched in VS Code.

Previously, since `processId` was set to `0`, VS Code let you choose between all processes running on the computer.

By setting `processId` to `"start_server"`, VS Code narrows down the list of processes to attach to to processes named `start_server`, yielding a much shorter list to pick from.