### PR TITLE
chore: build without optimizations for debug mode

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,20 +1,20 @@
 // See https://go.microsoft.com/fwlink/?LinkId=733558
 // for the documentation about the tasks.json format
 {
-	"version": "2.0.0",
-	"tasks": [
-		{
-			"label": "task: task build",
-			"type": "shell",
-			"command": "task build",
-			"presentation": {
-				"reveal": "silent",
-				"panel": "dedicated"
-			},
-			"group": {
-				"kind": "build",
-				"isDefault": true
-			}
-		}
-	]
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "task: task build",
+            "type": "shell",
+            "command": "task build:server:debug",
+            "presentation": {
+                "reveal": "silent",
+                "panel": "dedicated"
+            },
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            }
+        }
+    ]
 }

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -35,6 +35,15 @@ tasks:
           BIN_PATH: bin/start_server
           BUILD_FLAGS: $(./scripts/ldflags.sh)
           GO_FILE: cmd/start_server/start_server.go
+  
+  build:server:debug:
+    desc: Build server binary without optimizations
+    cmds:
+      - task: build:do
+        vars:
+          BIN_PATH: bin/start_server
+          BUILD_FLAGS: $(./scripts/ldflags.sh) -gcflags='all=-N -l'
+          GO_FILE: cmd/start_server/start_server.go
 
   build:test-tree-sitter:
     cmds:


### PR DESCRIPTION
This PR adds a task to the `Taskfile` to build the language server with all optimizations disabled. Optimizations made it harder to debug using Delve.

The `build:server:debug` task is used in `tasks.json` to make sure we build the non-optimized version when using VS Code.