### PR TITLE
Add July 2023 LinuxVM machine images as valid images

### DIFF
--- a/pkg/utils/machine_images.go
+++ b/pkg/utils/machine_images.go
@@ -10,6 +10,7 @@ var ValidARMOrMachineImagesUbuntu2004 = []string{
 	// Ubuntu 2004
 	"ubuntu-2004:current",
 	"ubuntu-2004:edge",
+	"ubuntu-2004:2023.07.1",
 	"ubuntu-2004:2023.04.2",
 	"ubuntu-2004:2023.04.1",
 	"ubuntu-2004:2023.02.1",
@@ -30,6 +31,7 @@ var ValidARMOrMachineImagesUbuntu2204 = []string{
 	// Ubuntu 2204
 	"ubuntu-2204:current",
 	"ubuntu-2204:edge",
+	"ubuntu-2204:2023.07.2",
 	"ubuntu-2204:2023.04.2",
 	"ubuntu-2204:2023.04.1",
 	"ubuntu-2204:2023.02.1",


### PR DESCRIPTION
# Description

The linux machine images
- https://circleci.com/developer/machine/image/ubuntu-2204
- https://circleci.com/developer/machine/image/ubuntu-2004

have new images released in at the beginning of July (07) https://discuss.circleci.com/t/linux-machine-executor-2023-q3-update/48580

Right now someone following the docs will get a language server error because the latest images are not present in the language server.

So, lets add in these new images


# Implementation details

Added the images to the existing arrays

# How to validate

> Add steps to setup the extension and check that the PR works

We should no longer see the image value be flagged as `Invalid or deprecated image`
```
jobs:
  test_job:
    machine:
      image: ubuntu-2204:2023.07.2
    resource_class: medium
    steps:
      - checkout
``` 

