### PR TITLE
ci: remove depency on cpe-slack context

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -700,7 +700,6 @@ workflows:
                 requires:
                     - Github Release
                 context:
-                    - cpe-slack
                     - devex-release
 
     Release management:


### PR DESCRIPTION
[Slack](https://circleci.slack.com/archives/C4C9J5KHN/p1695836239929519)
[Ask IT](https://circleci.atlassian.net/servicedesk/customer/portal/1/AIT-8870)

# Description

Stop using the `cpe-slack` context for Slack notifications.

# Implementation details

A new Slack bot was created

<img width="707" alt="Screenshot 2023-10-05 at 14 46 23" src="https://github.com/CircleCI-Public/circleci-yaml-language-server/assets/731497/aedf57d7-c20d-4f10-8521-09408e77c621">

Its token has been added to the `devex-release` context.

<img width="1017" alt="Screenshot 2023-10-05 at 15 33 50" src="https://github.com/CircleCI-Public/circleci-yaml-language-server/assets/731497/945c3043-a9ac-4216-9da5-60079db8f3b6">


