### PR TITLE
feat: DocumentSymbols also parse file from fs if cache failed

### DIFF
--- a/pkg/parser/yamlparser.go
+++ b/pkg/parser/yamlparser.go
@@ -1,6 +1,7 @@
 package parser
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"strconv"
@@ -141,13 +142,13 @@ func ParseFromURI(URI protocol.URI, context *utils.LsContext) (YamlDocument, err
 	return doc, err
 }
 
-const cacheMissingError = `file hasn't been opened`
+var CacheMissingError = errors.New("file not found in cache")
 
 func ParseFromUriWithCache(URI protocol.URI, cache *utils.Cache, context *utils.LsContext) (YamlDocument, error) {
 	cachedFile := cache.FileCache.GetFile(URI)
 
 	if cachedFile == nil {
-		return YamlDocument{}, fmt.Errorf("%s: %s", cacheMissingError, URI.Filename())
+		return YamlDocument{}, fmt.Errorf("%w: %s", CacheMissingError, URI.Filename())
 	}
 
 	content := []byte(cachedFile.TextDocument.Text)
@@ -155,13 +156,6 @@ func ParseFromUriWithCache(URI protocol.URI, cache *utils.Cache, context *utils.
 	doc, err := ParseFromContent(content, context, URI, protocol.Position{})
 
 	return doc, err
-}
-
-func IsCacheMissingError(err error) bool {
-	if err == nil {
-		return false
-	}
-	return strings.HasPrefix(err.Error(), cacheMissingError)
 }
 
 func ParseFromContent(content []byte, context *utils.LsContext, URI protocol.URI, offset protocol.Position) (YamlDocument, error) {

--- a/pkg/parser/yamlparser.go
+++ b/pkg/parser/yamlparser.go
@@ -141,11 +141,13 @@ func ParseFromURI(URI protocol.URI, context *utils.LsContext) (YamlDocument, err
 	return doc, err
 }
 
+const cacheMissingError = `file hasn't been opened`
+
 func ParseFromUriWithCache(URI protocol.URI, cache *utils.Cache, context *utils.LsContext) (YamlDocument, error) {
 	cachedFile := cache.FileCache.GetFile(URI)
 
 	if cachedFile == nil {
-		return YamlDocument{}, fmt.Errorf("file hasn't been opened: %s", URI.Filename())
+		return YamlDocument{}, fmt.Errorf("%s: %s", cacheMissingError, URI.Filename())
 	}
 
 	content := []byte(cachedFile.TextDocument.Text)
@@ -153,6 +155,13 @@ func ParseFromUriWithCache(URI protocol.URI, cache *utils.Cache, context *utils.
 	doc, err := ParseFromContent(content, context, URI, protocol.Position{})
 
 	return doc, err
+}
+
+func IsCacheMissingError(err error) bool {
+	if err == nil {
+		return false
+	}
+	return strings.HasPrefix(err.Error(), cacheMissingError)
 }
 
 func ParseFromContent(content []byte, context *utils.LsContext, URI protocol.URI, offset protocol.Position) (YamlDocument, error) {

--- a/pkg/parser/yamlparser_test.go
+++ b/pkg/parser/yamlparser_test.go
@@ -13,6 +13,15 @@ import (
 	"go.lsp.dev/uri"
 )
 
+func TestCacheMissingError(t *testing.T) {
+	cache := utils.CreateCache()
+	_, err := parser.ParseFromUriWithCache(uri.New("file:///toto.yaml"), cache, nil)
+
+	if assert.Error(t, err) {
+		assert.ErrorIs(t, err, parser.CacheMissingError)
+	}
+}
+
 func TestJobExecutorMachineTrueOnApp(t *testing.T) {
 	yaml := `version: 2.1
 jobs:

--- a/pkg/server/methods/textDocumentSymbols.go
+++ b/pkg/server/methods/textDocumentSymbols.go
@@ -15,7 +15,7 @@ func (methods *Methods) DocumentSymbols(reply jsonrpc2.Replier, req jsonrpc2.Req
 		return reply(methods.Ctx, nil, fmt.Errorf("%s: %w", jsonrpc2.ErrParse, err))
 	}
 
-	res, _ := languageservice.DocumentSymbols(params, methods.Cache, methods.LsContext)
+	res, err := languageservice.DocumentSymbols(params, methods.Cache, methods.LsContext)
 
-	return reply(methods.Ctx, res, nil)
+	return reply(methods.Ctx, res, err)
 }

--- a/pkg/services/documentSymbols.go
+++ b/pkg/services/documentSymbols.go
@@ -10,6 +10,10 @@ import (
 func DocumentSymbols(params protocol.DocumentSymbolParams, cache *utils.Cache, context *utils.LsContext) ([]protocol.DocumentSymbol, error) {
 	yamlDocument, err := yamlparser.ParseFromUriWithCache(params.TextDocument.URI, cache, context)
 
+	if yamlparser.IsCacheMissingError(err) {
+		yamlDocument, err = yamlparser.ParseFromURI(params.TextDocument.URI, context)
+	}
+
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/services/documentSymbols.go
+++ b/pkg/services/documentSymbols.go
@@ -1,6 +1,8 @@
 package languageservice
 
 import (
+	"errors"
+
 	yamlparser "github.com/CircleCI-Public/circleci-yaml-language-server/pkg/parser"
 	"github.com/CircleCI-Public/circleci-yaml-language-server/pkg/services/documentSymbols"
 	"github.com/CircleCI-Public/circleci-yaml-language-server/pkg/utils"
@@ -10,7 +12,7 @@ import (
 func DocumentSymbols(params protocol.DocumentSymbolParams, cache *utils.Cache, context *utils.LsContext) ([]protocol.DocumentSymbol, error) {
 	yamlDocument, err := yamlparser.ParseFromUriWithCache(params.TextDocument.URI, cache, context)
 
-	if yamlparser.IsCacheMissingError(err) {
+	if errors.Is(err, yamlparser.CacheMissingError) {
 		yamlDocument, err = yamlparser.ParseFromURI(params.TextDocument.URI, context)
 	}
 


### PR DESCRIPTION
add IsCacheMissingError to yamlparser

[Jira](https://circleci.atlassian.net/browse/DEVEX-1321)

# Description

This PR adds a fallback to the method DocumentSymbols in order to try to parse the file referenced by the uri from the filesystem if parsing from the cache failed.
