### PR TITLE
fix: parameter flagged due type mismatch even it shouldnt

### DIFF
--- a/pkg/parser/validate/parameters.go
+++ b/pkg/parser/validate/parameters.go
@@ -35,14 +35,9 @@ func (val Validate) checkIfParamAssigned(params map[string]ast.ParameterValue, d
 }
 
 func (val Validate) checkParamSimpleType(param ast.ParameterValue, stepName string, definedParam ast.Parameter) {
-	paramName, _ := utils.GetParamNameUsedAtPos(val.Doc.Content, param.Range.End)
 	switch definedParam.GetType() {
-	case "string":
-		checkParamType(paramName, "string", val, param, stepName, definedParam)
-	case "boolean":
-		checkParamType(paramName, "boolean", val, param, stepName, definedParam)
-	case "integer":
-		checkParamType(paramName, "integer", val, param, stepName, definedParam)
+	case "string", "boolean", "integer":
+		checkParamType(definedParam.GetType(), val, param, stepName, definedParam)
 	case "enum":
 		if param.Type != "string" {
 			val.createParameterError(param, stepName, "string")
@@ -93,7 +88,8 @@ func (val Validate) checkParamSimpleType(param ast.ParameterValue, stepName stri
 	}
 }
 
-func checkParamType(paramName string, paramType string, val Validate, param ast.ParameterValue, stepName string, definedParam ast.Parameter) {
+func checkParamType(paramType string, val Validate, param ast.ParameterValue, stepName string, definedParam ast.Parameter) {
+	paramName, _ := utils.GetParamNameUsedAtPos(val.Doc.Content, param.Range.End)
 	if paramName != "" {
 		pipelineParam, ok := val.Doc.PipelineParameters[paramName]
 		if ok && pipelineParam.GetType() != paramType {

--- a/pkg/parser/validate/parameters.go
+++ b/pkg/parser/validate/parameters.go
@@ -35,22 +35,14 @@ func (val Validate) checkIfParamAssigned(params map[string]ast.ParameterValue, d
 }
 
 func (val Validate) checkParamSimpleType(param ast.ParameterValue, stepName string, definedParam ast.Parameter) {
+	paramName, _ := utils.GetParamNameUsedAtPos(val.Doc.Content, param.Range.End)
 	switch definedParam.GetType() {
 	case "string":
-		if param.Type != "string" {
-			val.createParameterError(param, stepName, definedParam.GetType())
-		}
-
+		checkParamType(paramName, "string", val, param, stepName, definedParam)
 	case "boolean":
-		if param.Type != "boolean" {
-			val.createParameterError(param, stepName, definedParam.GetType())
-		}
-
+		checkParamType(paramName, "boolean", val, param, stepName, definedParam)
 	case "integer":
-		if param.Type != "integer" {
-			val.createParameterError(param, stepName, definedParam.GetType())
-		}
-
+		checkParamType(paramName, "integer", val, param, stepName, definedParam)
 	case "enum":
 		if param.Type != "string" {
 			val.createParameterError(param, stepName, "string")
@@ -98,6 +90,17 @@ func (val Validate) checkParamSimpleType(param ast.ParameterValue, stepName stri
 			return
 		}
 		// TODO: check if POSIX_REGEX is valid
+	}
+}
+
+func checkParamType(paramName string, paramType string, val Validate, param ast.ParameterValue, stepName string, definedParam ast.Parameter) {
+	if paramName != "" {
+		pipelineParam, ok := val.Doc.PipelineParameters[paramName]
+		if ok && pipelineParam.GetType() != paramType {
+			val.createParameterError(param, stepName, definedParam.GetType())
+		}
+	} else if param.Type != paramType {
+		val.createParameterError(param, stepName, definedParam.GetType())
 	}
 }
 

--- a/pkg/parser/validate/parameters_test.go
+++ b/pkg/parser/validate/parameters_test.go
@@ -1,0 +1,71 @@
+package validate
+
+import (
+	"os"
+	"testing"
+
+	"github.com/CircleCI-Public/circleci-yaml-language-server/pkg/utils"
+	"go.lsp.dev/protocol"
+)
+
+func TestJobParameterType(t *testing.T) {
+	correctParamFilePath := "./testdata/correct_param_type.yml"
+	correctParamFileContent, err := os.ReadFile(correctParamFilePath)
+	if err != nil {
+		panic(err)
+	}
+	wrongParamFilePath := "./testdata/wrong_param_type.yml"
+	wrongParamFileContent, err2 := os.ReadFile(wrongParamFilePath)
+	if err2 != nil {
+		panic(err2)
+	}
+	wrongParamIntegerFilePath := "./testdata/wrong_param_type_integer.yml"
+	wrongParamIntegerFileContent, err2 := os.ReadFile(wrongParamIntegerFilePath)
+	if err2 != nil {
+		panic(err2)
+	}
+	wrongParamBooleanFilePath := "./testdata/wrong_param_type_boolean.yml"
+	wrongParamBooleanFileContent, err2 := os.ReadFile(wrongParamBooleanFilePath)
+	if err2 != nil {
+		panic(err2)
+	}
+	testCases := []ValidateTestCase{
+		{
+			Name:        "Using a global Parameter on a job parameter with the same type definition should not result in error",
+			YamlContent: string(correctParamFileContent),
+			Diagnostics: []protocol.Diagnostic{},
+		},
+		{
+			Name:        "Parameter usage should error when param usage is different from param definition",
+			YamlContent: string(wrongParamFileContent),
+			Diagnostics: []protocol.Diagnostic{
+				utils.CreateErrorDiagnosticFromRange(protocol.Range{
+					Start: protocol.Position{Line: 24, Character: 9},
+					End:   protocol.Position{Line: 24, Character: 54},
+				}, "Parameter skip for build must be a string"),
+			},
+		},
+		{
+			Name:        "Parameter usage should error when param usage is different from param definition",
+			YamlContent: string(wrongParamIntegerFileContent),
+			Diagnostics: []protocol.Diagnostic{
+				utils.CreateErrorDiagnosticFromRange(protocol.Range{
+					Start: protocol.Position{Line: 24, Character: 9},
+					End:   protocol.Position{Line: 24, Character: 54},
+				}, "Parameter skip for build must be a boolean"),
+			},
+		},
+		{
+			Name:        "Parameter usage should error when param usage is different from param definition",
+			YamlContent: string(wrongParamBooleanFileContent),
+			Diagnostics: []protocol.Diagnostic{
+				utils.CreateErrorDiagnosticFromRange(protocol.Range{
+					Start: protocol.Position{Line: 24, Character: 9},
+					End:   protocol.Position{Line: 24, Character: 54},
+				}, "Parameter skip for build must be a boolean"),
+			},
+		},
+	}
+
+	CheckYamlErrors(t, testCases)
+}

--- a/pkg/parser/validate/testdata/correct_param_type.yml
+++ b/pkg/parser/validate/testdata/correct_param_type.yml
@@ -1,0 +1,25 @@
+version: 2.1 # Use version 2.1 to enable Orb usage.
+
+parameters:
+  skipUnitTests:
+    description: if set to true will not build the c++ unit tests
+    type: boolean
+    default: false
+
+jobs:
+  build:
+    parameters:
+      skip:
+        type: boolean
+        default: false
+    docker:
+      - image: cimg/base:edge
+    steps:
+      - checkout
+      - run: echo "This was triggered by << pipeline.trigger_source >>"
+      
+workflows:
+  commit:
+   jobs:
+     - build:
+         skip: << pipeline.parameters.skipUnitTests >>

--- a/pkg/parser/validate/testdata/wrong_param_type.yml
+++ b/pkg/parser/validate/testdata/wrong_param_type.yml
@@ -1,0 +1,25 @@
+version: 2.1 # Use version 2.1 to enable Orb usage.
+
+parameters:
+  skipUnitTests:
+    description: if set to true will not build the c++ unit tests
+    type: boolean
+    default: false
+
+jobs:
+  build:
+    parameters:
+      skip:
+        type: string
+        default: "stringParam"
+    docker:
+      - image: cimg/base:edge
+    steps:
+      - checkout
+      - run: echo "This was triggered by << pipeline.trigger_source >>"
+      
+workflows:
+  commit:
+   jobs:
+     - build:
+         skip: << pipeline.parameters.skipUnitTests >>

--- a/pkg/parser/validate/testdata/wrong_param_type_boolean.yml
+++ b/pkg/parser/validate/testdata/wrong_param_type_boolean.yml
@@ -1,0 +1,25 @@
+version: 2.1 # Use version 2.1 to enable Orb usage.
+
+parameters:
+  skipUnitTests:
+    description: if set to true will not build the c++ unit tests
+    type: string
+    default: "2"
+
+jobs:
+  build:
+    parameters:
+      skip:
+        type: boolean
+        default: false
+    docker:
+      - image: cimg/base:edge
+    steps:
+      - checkout
+      - run: echo "This was triggered by << pipeline.trigger_source >>"
+      
+workflows:
+  commit:
+   jobs:
+     - build:
+         skip: << pipeline.parameters.skipUnitTests >>

--- a/pkg/parser/validate/testdata/wrong_param_type_integer.yml
+++ b/pkg/parser/validate/testdata/wrong_param_type_integer.yml
@@ -1,0 +1,25 @@
+version: 2.1 # Use version 2.1 to enable Orb usage.
+
+parameters:
+  skipUnitTests:
+    description: if set to true will not build the c++ unit tests
+    type: integer
+    default: 2
+
+jobs:
+  build:
+    parameters:
+      skip:
+        type: boolean
+        default: false
+    docker:
+      - image: cimg/base:edge
+    steps:
+      - checkout
+      - run: echo "This was triggered by << pipeline.trigger_source >>"
+      
+workflows:
+  commit:
+   jobs:
+     - build:
+         skip: << pipeline.parameters.skipUnitTests >>


### PR DESCRIPTION
[Jira](https://circleci.atlassian.net/browse/XXXX-1234)

# Description

When Parameter is a boolean, the LS flags it as an error when passed to a job that is  expecting a boolean parameter

# Implementation details

When the passed parameter refer to global parameter, check the global parameter type  

# How to validate

Check tests
and test this config file 
```
version: 2.1 # Use version 2.1 to enable Orb usage.

parameters:
  skipUnitTests:
    description: if set to true will not build the c++ unit tests
    type: boolean
    default: false

jobs:
  build:
    parameters:
      skip:
        type: boolean
        default: false
    docker:
      - image: cimg/base:edge
    steps:
      - checkout
      - run: echo "This was triggered by << pipeline.trigger_source >>"
      
workflows:
  commit:
   jobs:
     - build:
         skip: << pipeline.parameters.skipUnitTests >>
```

