### PR TITLE
feat: add setup true in the returned outline of the ls

### DIFF
--- a/e2e/__snapshots__/documentSymbol.test.ts.snap
+++ b/e2e/__snapshots__/documentSymbol.test.ts.snap
@@ -28,9 +28,9 @@ exports[`DocumentSymbol File with continuation workflow 1`] = `
     },
   },
   {
-    "detail": "Continuation workflow enabled",
-    "kind": 14,
-    "name": "setup: true",
+    "detail": "true",
+    "kind": 17,
+    "name": "Setup",
     "range": {
       "end": {
         "character": 11,

--- a/e2e/__snapshots__/documentSymbol.test.ts.snap
+++ b/e2e/__snapshots__/documentSymbol.test.ts.snap
@@ -1,0 +1,768 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`DocumentSymbol File with continuation workflow 1`] = `
+[
+  {
+    "detail": "2.1",
+    "kind": 0,
+    "name": "Version",
+    "range": {
+      "end": {
+        "character": 12,
+        "line": 0,
+      },
+      "start": {
+        "character": 0,
+        "line": 0,
+      },
+    },
+    "selectionRange": {
+      "end": {
+        "character": 12,
+        "line": 0,
+      },
+      "start": {
+        "character": 0,
+        "line": 0,
+      },
+    },
+  },
+  {
+    "detail": "Continuation workflow enabled",
+    "kind": 14,
+    "name": "setup: true",
+    "range": {
+      "end": {
+        "character": 11,
+        "line": 2,
+      },
+      "start": {
+        "character": 0,
+        "line": 2,
+      },
+    },
+    "selectionRange": {
+      "end": {
+        "character": 11,
+        "line": 2,
+      },
+      "start": {
+        "character": 0,
+        "line": 2,
+      },
+    },
+  },
+  {
+    "children": [
+      {
+        "detail": "0.1.2",
+        "kind": 12,
+        "name": "continuation",
+        "range": {
+          "end": {
+            "character": 43,
+            "line": 5,
+          },
+          "start": {
+            "character": 2,
+            "line": 5,
+          },
+        },
+        "selectionRange": {
+          "end": {
+            "character": 43,
+            "line": 5,
+          },
+          "start": {
+            "character": 2,
+            "line": 5,
+          },
+        },
+      },
+    ],
+    "kind": 18,
+    "name": "Orbs",
+    "range": {
+      "end": {
+        "character": 43,
+        "line": 5,
+      },
+      "start": {
+        "character": 2,
+        "line": 5,
+      },
+    },
+    "selectionRange": {
+      "end": {
+        "character": 43,
+        "line": 5,
+      },
+      "start": {
+        "character": 2,
+        "line": 5,
+      },
+    },
+  },
+  {
+    "children": [
+      {
+        "children": [
+          {
+            "children": [
+              {
+                "kind": 1,
+                "name": "checkout",
+                "range": {
+                  "end": {
+                    "character": 16,
+                    "line": 11,
+                  },
+                  "start": {
+                    "character": 8,
+                    "line": 11,
+                  },
+                },
+                "selectionRange": {
+                  "end": {
+                    "character": 16,
+                    "line": 11,
+                  },
+                  "start": {
+                    "character": 8,
+                    "line": 11,
+                  },
+                },
+              },
+              {
+                "kind": 1,
+                "name": "Generate config",
+                "range": {
+                  "end": {
+                    "character": 11,
+                    "line": 12,
+                  },
+                  "start": {
+                    "character": 8,
+                    "line": 12,
+                  },
+                },
+                "selectionRange": {
+                  "end": {
+                    "character": 11,
+                    "line": 12,
+                  },
+                  "start": {
+                    "character": 8,
+                    "line": 12,
+                  },
+                },
+              },
+              {
+                "kind": 1,
+                "name": "continuation/continue",
+                "range": {
+                  "end": {
+                    "character": 29,
+                    "line": 16,
+                  },
+                  "start": {
+                    "character": 8,
+                    "line": 16,
+                  },
+                },
+                "selectionRange": {
+                  "end": {
+                    "character": 29,
+                    "line": 16,
+                  },
+                  "start": {
+                    "character": 8,
+                    "line": 16,
+                  },
+                },
+              },
+            ],
+            "detail": "3 total",
+            "kind": 18,
+            "name": "Steps",
+            "range": {
+              "end": {
+                "character": 50,
+                "line": 17,
+              },
+              "start": {
+                "character": 4,
+                "line": 10,
+              },
+            },
+            "selectionRange": {
+              "end": {
+                "character": 50,
+                "line": 17,
+              },
+              "start": {
+                "character": 4,
+                "line": 10,
+              },
+            },
+          },
+          {
+            "kind": 6,
+            "name": "Executor: continuation/default",
+            "range": {
+              "end": {
+                "character": 34,
+                "line": 9,
+              },
+              "start": {
+                "character": 4,
+                "line": 9,
+              },
+            },
+            "selectionRange": {
+              "end": {
+                "character": 34,
+                "line": 9,
+              },
+              "start": {
+                "character": 4,
+                "line": 9,
+              },
+            },
+          },
+        ],
+        "kind": 1,
+        "name": "setup",
+        "range": {
+          "end": {
+            "character": 50,
+            "line": 17,
+          },
+          "start": {
+            "character": 2,
+            "line": 8,
+          },
+        },
+        "selectionRange": {
+          "end": {
+            "character": 50,
+            "line": 17,
+          },
+          "start": {
+            "character": 2,
+            "line": 8,
+          },
+        },
+      },
+    ],
+    "kind": 18,
+    "name": "Jobs",
+    "range": {
+      "end": {
+        "character": 50,
+        "line": 17,
+      },
+      "start": {
+        "character": 2,
+        "line": 8,
+      },
+    },
+    "selectionRange": {
+      "end": {
+        "character": 50,
+        "line": 17,
+      },
+      "start": {
+        "character": 2,
+        "line": 8,
+      },
+    },
+  },
+  {
+    "children": [
+      {
+        "children": [
+          {
+            "children": [
+              {
+                "kind": 0,
+                "name": "setup",
+                "range": {
+                  "end": {
+                    "character": 13,
+                    "line": 22,
+                  },
+                  "start": {
+                    "character": 6,
+                    "line": 22,
+                  },
+                },
+                "selectionRange": {
+                  "end": {
+                    "character": 13,
+                    "line": 22,
+                  },
+                  "start": {
+                    "character": 6,
+                    "line": 22,
+                  },
+                },
+              },
+            ],
+            "kind": 18,
+            "name": "Jobs",
+            "range": {
+              "end": {
+                "character": 0,
+                "line": 23,
+              },
+              "start": {
+                "character": 4,
+                "line": 21,
+              },
+            },
+            "selectionRange": {
+              "end": {
+                "character": 0,
+                "line": 23,
+              },
+              "start": {
+                "character": 4,
+                "line": 21,
+              },
+            },
+          },
+        ],
+        "kind": 23,
+        "name": "setup",
+        "range": {
+          "end": {
+            "character": 0,
+            "line": 23,
+          },
+          "start": {
+            "character": 2,
+            "line": 20,
+          },
+        },
+        "selectionRange": {
+          "end": {
+            "character": 0,
+            "line": 23,
+          },
+          "start": {
+            "character": 2,
+            "line": 20,
+          },
+        },
+      },
+    ],
+    "kind": 18,
+    "name": "Workflows",
+    "range": {
+      "end": {
+        "character": 0,
+        "line": 23,
+      },
+      "start": {
+        "character": 2,
+        "line": 20,
+      },
+    },
+    "selectionRange": {
+      "end": {
+        "character": 0,
+        "line": 23,
+      },
+      "start": {
+        "character": 2,
+        "line": 20,
+      },
+    },
+  },
+]
+`;
+
+exports[`DocumentSymbol Standard file 1`] = `
+[
+  {
+    "detail": "2.1",
+    "kind": 0,
+    "name": "Version",
+    "range": {
+      "end": {
+        "character": 12,
+        "line": 0,
+      },
+      "start": {
+        "character": 0,
+        "line": 0,
+      },
+    },
+    "selectionRange": {
+      "end": {
+        "character": 12,
+        "line": 0,
+      },
+      "start": {
+        "character": 0,
+        "line": 0,
+      },
+    },
+  },
+  {
+    "children": [
+      {
+        "detail": "2",
+        "kind": 12,
+        "name": "macos",
+        "range": {
+          "end": {
+            "character": 25,
+            "line": 3,
+          },
+          "start": {
+            "character": 2,
+            "line": 3,
+          },
+        },
+        "selectionRange": {
+          "end": {
+            "character": 25,
+            "line": 3,
+          },
+          "start": {
+            "character": 2,
+            "line": 3,
+          },
+        },
+      },
+    ],
+    "kind": 18,
+    "name": "Orbs",
+    "range": {
+      "end": {
+        "character": 25,
+        "line": 3,
+      },
+      "start": {
+        "character": 2,
+        "line": 3,
+      },
+    },
+    "selectionRange": {
+      "end": {
+        "character": 25,
+        "line": 3,
+      },
+      "start": {
+        "character": 2,
+        "line": 3,
+      },
+    },
+  },
+  {
+    "children": [
+      {
+        "children": [
+          {
+            "children": [
+              {
+                "kind": 1,
+                "name": "checkout",
+                "range": {
+                  "end": {
+                    "character": 18,
+                    "line": 13,
+                  },
+                  "start": {
+                    "character": 10,
+                    "line": 13,
+                  },
+                },
+                "selectionRange": {
+                  "end": {
+                    "character": 18,
+                    "line": 13,
+                  },
+                  "start": {
+                    "character": 10,
+                    "line": 13,
+                  },
+                },
+              },
+              {
+                "kind": 1,
+                "name": "run",
+                "range": {
+                  "end": {
+                    "character": 13,
+                    "line": 14,
+                  },
+                  "start": {
+                    "character": 10,
+                    "line": 14,
+                  },
+                },
+                "selectionRange": {
+                  "end": {
+                    "character": 13,
+                    "line": 14,
+                  },
+                  "start": {
+                    "character": 10,
+                    "line": 14,
+                  },
+                },
+              },
+              {
+                "kind": 1,
+                "name": "macos/switch-ruby",
+                "range": {
+                  "end": {
+                    "character": 27,
+                    "line": 15,
+                  },
+                  "start": {
+                    "character": 10,
+                    "line": 15,
+                  },
+                },
+                "selectionRange": {
+                  "end": {
+                    "character": 27,
+                    "line": 15,
+                  },
+                  "start": {
+                    "character": 10,
+                    "line": 15,
+                  },
+                },
+              },
+            ],
+            "detail": "3 total",
+            "kind": 18,
+            "name": "Steps",
+            "range": {
+              "end": {
+                "character": 24,
+                "line": 16,
+              },
+              "start": {
+                "character": 4,
+                "line": 12,
+              },
+            },
+            "selectionRange": {
+              "end": {
+                "character": 24,
+                "line": 16,
+              },
+              "start": {
+                "character": 4,
+                "line": 12,
+              },
+            },
+          },
+          {
+            "children": [
+              {
+                "kind": 8,
+                "name": "cimg/node:17.2.0",
+                "range": {
+                  "end": {
+                    "character": 31,
+                    "line": 8,
+                  },
+                  "start": {
+                    "character": 8,
+                    "line": 8,
+                  },
+                },
+                "selectionRange": {
+                  "end": {
+                    "character": 31,
+                    "line": 8,
+                  },
+                  "start": {
+                    "character": 8,
+                    "line": 8,
+                  },
+                },
+              },
+            ],
+            "kind": 13,
+            "name": "Docker",
+            "range": {
+              "end": {
+                "character": 24,
+                "line": 16,
+              },
+              "start": {
+                "character": 2,
+                "line": 6,
+              },
+            },
+            "selectionRange": {
+              "end": {
+                "character": 24,
+                "line": 16,
+              },
+              "start": {
+                "character": 2,
+                "line": 6,
+              },
+            },
+          },
+        ],
+        "kind": 1,
+        "name": "build",
+        "range": {
+          "end": {
+            "character": 24,
+            "line": 16,
+          },
+          "start": {
+            "character": 2,
+            "line": 6,
+          },
+        },
+        "selectionRange": {
+          "end": {
+            "character": 24,
+            "line": 16,
+          },
+          "start": {
+            "character": 2,
+            "line": 6,
+          },
+        },
+      },
+    ],
+    "kind": 18,
+    "name": "Jobs",
+    "range": {
+      "end": {
+        "character": 24,
+        "line": 16,
+      },
+      "start": {
+        "character": 2,
+        "line": 6,
+      },
+    },
+    "selectionRange": {
+      "end": {
+        "character": 24,
+        "line": 16,
+      },
+      "start": {
+        "character": 2,
+        "line": 6,
+      },
+    },
+  },
+  {
+    "children": [
+      {
+        "children": [
+          {
+            "children": [
+              {
+                "kind": 0,
+                "name": "build",
+                "range": {
+                  "end": {
+                    "character": 13,
+                    "line": 21,
+                  },
+                  "start": {
+                    "character": 6,
+                    "line": 21,
+                  },
+                },
+                "selectionRange": {
+                  "end": {
+                    "character": 13,
+                    "line": 21,
+                  },
+                  "start": {
+                    "character": 6,
+                    "line": 21,
+                  },
+                },
+              },
+            ],
+            "kind": 18,
+            "name": "Jobs",
+            "range": {
+              "end": {
+                "character": 0,
+                "line": 24,
+              },
+              "start": {
+                "character": 4,
+                "line": 20,
+              },
+            },
+            "selectionRange": {
+              "end": {
+                "character": 0,
+                "line": 24,
+              },
+              "start": {
+                "character": 4,
+                "line": 20,
+              },
+            },
+          },
+        ],
+        "kind": 23,
+        "name": "test-build",
+        "range": {
+          "end": {
+            "character": 0,
+            "line": 24,
+          },
+          "start": {
+            "character": 2,
+            "line": 19,
+          },
+        },
+        "selectionRange": {
+          "end": {
+            "character": 0,
+            "line": 24,
+          },
+          "start": {
+            "character": 2,
+            "line": 19,
+          },
+        },
+      },
+    ],
+    "kind": 18,
+    "name": "Workflows",
+    "range": {
+      "end": {
+        "character": 0,
+        "line": 24,
+      },
+      "start": {
+        "character": 2,
+        "line": 19,
+      },
+    },
+    "selectionRange": {
+      "end": {
+        "character": 0,
+        "line": 24,
+      },
+      "start": {
+        "character": 2,
+        "line": 19,
+      },
+    },
+  },
+]
+`;

--- a/e2e/completion.test.ts
+++ b/e2e/completion.test.ts
@@ -1,7 +1,4 @@
-import {
-  commands,
-  position,
-} from './utils';
+import { commands, position } from './utils';
 
 describe('Completion command', () => {
   jest.setTimeout(10000);

--- a/e2e/documentSymbol.test.ts
+++ b/e2e/documentSymbol.test.ts
@@ -1,0 +1,21 @@
+import { commands } from './utils';
+
+describe('DocumentSymbol', () => {
+  it('Standard file', async () => {
+    const testingFile = 'config1.yml';
+    await commands.didOpen(testingFile);
+
+    const res = await commands.documentSymbol(testingFile);
+
+    expect(res).toMatchSnapshot();
+  });
+
+  it('File with continuation workflow', async () => {
+    const testingFile = 'continuation.yml';
+    await commands.didOpen(testingFile);
+
+    const res = await commands.documentSymbol(testingFile);
+
+    expect(res).toMatchSnapshot();
+  });
+});

--- a/e2e/utils/commands.ts
+++ b/e2e/utils/commands.ts
@@ -1,17 +1,8 @@
 import * as utils from './helpers';
-import {
-  Commands,
-} from './types';
-import type {
-  CompletionList,
-  HoverCommandResponse,
-  Position,
-} from './types';
+import { Commands, DocumentSymbolResponse } from './types';
+import type { CompletionList, HoverCommandResponse, Position } from './types';
 import DiagnosticList from './DiagnosticList';
-import {
-  configFileContent,
-  configFileUri,
-} from '../.env';
+import { configFileContent, configFileUri } from '../.env';
 
 async function didOpen(
   filePath: string,
@@ -19,18 +10,15 @@ async function didOpen(
 
   // Number of milliseconds to wait for orbs to be fetched
   waitOrbLoading = 3000,
-) : Promise<DiagnosticList> {
-  const response = await utils.command(
-    Commands.DocumentDidOpen,
-    {
-      textDocument: {
-        text: await configFileContent(filePath, 'utf-8'),
-        uri: configFileUri(filePath),
-        version,
-        languageId: 'yaml',
-      },
+): Promise<DiagnosticList> {
+  const response = await utils.command(Commands.DocumentDidOpen, {
+    textDocument: {
+      text: await configFileContent(filePath, 'utf-8'),
+      uri: configFileUri(filePath),
+      version,
+      languageId: 'yaml',
     },
-  );
+  });
 
   const diagnostics = utils.immediateDiagnostics();
 
@@ -47,15 +35,12 @@ async function complete(
   filename: string,
   position: Position,
 ): Promise<CompletionList> {
-  const response = await utils.command(
-    Commands.Completion,
-    {
-      position,
-      textDocument: {
-        uri: configFileUri(filename),
-      },
+  const response = (await utils.command(Commands.Completion, {
+    position,
+    textDocument: {
+      uri: configFileUri(filename),
     },
-  ) as CompletionList;
+  })) as CompletionList;
 
   response.items.sort((a, b) => a.label.localeCompare(b.label));
 
@@ -66,21 +51,27 @@ async function hover(
   filename: string,
   position: Position,
 ): Promise<HoverCommandResponse> {
-  const response = await utils.command(
-    Commands.DocumentHover,
-    {
-      position,
-      textDocument: {
-        uri: configFileUri(filename),
-      },
+  const response = (await utils.command(Commands.DocumentHover, {
+    position,
+    textDocument: {
+      uri: configFileUri(filename),
     },
-  ) as HoverCommandResponse;
+  })) as HoverCommandResponse;
 
   return response;
 }
 
+async function documentSymbol(
+  filename: string,
+): Promise<DocumentSymbolResponse> {
+  const response = (await utils.command(Commands.DocumentSymbol, {
+    textDocument: {
+      uri: configFileUri(filename),
+    },
+  })) as DocumentSymbolResponse;
+  return response;
+}
+
 export {
-  complete,
-  didOpen,
-  hover,
+  complete, didOpen, hover, documentSymbol,
 };

--- a/e2e/utils/types.ts
+++ b/e2e/utils/types.ts
@@ -10,6 +10,7 @@ enum Commands {
   Shutdown = 'shutdown',
   Exit = 'exit',
   PublishDiagnostics = 'textDocument/publishDiagnostics',
+  DocumentSymbol = 'textDocument/documentSymbol',
 }
 
 enum DiagnosticSeverity {
@@ -30,99 +31,103 @@ type LanguageIdentifier = string;
 type TriggerKind = number;
 
 type CodeDescription = {
-  href: string,
+  href: string;
 };
 
 type CompletionList = {
-  isIncomplete: boolean,
-  items: CompletionItem[],
+  isIncomplete: boolean;
+  items: CompletionItem[];
 };
 
 type HoverCommandResponse = {
   contents: {
-    kind: string,
-    value: string,
-  },
+    kind: string;
+    value: string;
+  };
 
-  range?: Range,
+  range?: Range;
 };
 
+type DocumentSymbol = unknown;
+
+type DocumentSymbolResponse = DocumentSymbol[];
+
 type CompletionItem = {
-  label: string,
+  label: string;
 };
 
 type CompletionContext = {
-  triggerCharacter?: string,
-  triggerKind?: TriggerKind,
+  triggerCharacter?: string;
+  triggerKind?: TriggerKind;
 };
 
 type DiagnosticRelatedInformation = {
-  location: Location,
-  message: string,
+  location: Location;
+  message: string;
 };
 
 type Diagnostic = {
-  range: Range,
-  severity?: DiagnosticSeverity
-  code?: string | number,
-  codeDescription?: CodeDescription,
-  source?: string,
-  message: string,
-  tags?: DiagnosticTag[],
-  relatedInformation?: DiagnosticRelatedInformation[],
-  data?: unknown,
+  range: Range;
+  severity?: DiagnosticSeverity;
+  code?: string | number;
+  codeDescription?: CodeDescription;
+  source?: string;
+  message: string;
+  tags?: DiagnosticTag[];
+  relatedInformation?: DiagnosticRelatedInformation[];
+  data?: unknown;
 };
 
 type Location = {
-  uri: DocumentURI,
-  range: Range,
+  uri: DocumentURI;
+  range: Range;
 };
 
 type PartialResultParams = {
-  partialResultToken?: ProgressToken,
+  partialResultToken?: ProgressToken;
 };
 
 type Position = {
-  line: number,
-  character: number,
+  line: number;
+  character: number;
 };
 
 type ProgressToken = {
-  name: string,
-  number: number,
+  name: string;
+  number: number;
 };
 
 type Range = {
-  start: Position,
-  end: Position,
+  start: Position;
+  end: Position;
 };
 
 type TextDocumentContentChangeEvent = {
   // Range is the range of the document that changed.
-  range: Range,
+  range: Range;
 
   // RangeLength is the length of the range that got replaced.
-  rangeLength?: number,
+  rangeLength?: number;
 
   // Text is the new text of the document.
-  text: string,
+  text: string;
 };
 
 type TextDocumentItem = {
   textDocument: {
-    languageId: LanguageIdentifier
+    languageId: LanguageIdentifier;
 
-    text: string,
-  } & VersionedTextDocumentIdentifier
+    text: string;
+  } & VersionedTextDocumentIdentifier;
 };
 
 type VersionedTextDocumentIdentifier = {
-  uri: DocumentURI,
-  version: DocumentVersion,
+  uri: DocumentURI;
+  version: DocumentVersion;
 };
 
 type WorkDoneProgressParams = {
-  workDoneToken?: ProgressToken,
+  workDoneToken?: ProgressToken;
 };
 
 type DocumentDidOpenCommand = TextDocumentItem;
@@ -133,76 +138,75 @@ type DocumentDidChange = {
   // TextDocument is the document that did change. The version number points
   // to the version after all provided content changes have
   // been applied.
-  textDocument: VersionedTextDocumentIdentifier,
+  textDocument: VersionedTextDocumentIdentifier;
 
   // ContentChanges is the actual content changes. The content changes describe single state changes
   // to the document. So if there are two content changes c1 and c2 for a document
   // in state S then c1 move the document to S' and c2 to S''.
-  contentChanges: TextDocumentContentChangeEvent[],
+  contentChanges: TextDocumentContentChangeEvent[];
 };
 
 type ReferenceContext = {
-  includeDeclaration: boolean,
+  includeDeclaration: boolean;
 };
 
 type TextDocumentPositionParams = {
-  textDocument: TextDocumentIdentifier,
-  position: Position,
+  textDocument: TextDocumentIdentifier;
+  position: Position;
 };
 
 type TextDocumentIdentifier = {
-  uri: DocumentURI,
+  uri: DocumentURI;
 };
 
 // ============================================================
 // RPC Parameters
-type DocumentHover =
-  & TextDocumentPositionParams
-  & WorkDoneProgressParams;
+type DocumentHover = TextDocumentPositionParams & WorkDoneProgressParams;
 
 type SemanticTokensParams = {
-  textDocument: TextDocumentIdentifier,
-}
-& PartialResultParams
-& WorkDoneProgressParams;
+  textDocument: TextDocumentIdentifier;
+} & PartialResultParams &
+WorkDoneProgressParams;
 
-type DefinitionParams =
-  & TextDocumentPositionParams
-  & WorkDoneProgressParams
-  & PartialResultParams;
+type DefinitionParams = TextDocumentPositionParams &
+WorkDoneProgressParams &
+PartialResultParams;
 
 type ReferenceParams = {
-  context: ReferenceContext,
-}
-& TextDocumentPositionParams
-& WorkDoneProgressParams
-& PartialResultParams;
+  context: ReferenceContext;
+} & TextDocumentPositionParams &
+WorkDoneProgressParams &
+PartialResultParams;
 
 type CompletionParams = {
-  context?: CompletionContext,
-}
-& TextDocumentPositionParams
-& WorkDoneProgressParams
-& PartialResultParams;
+  context?: CompletionContext;
+} & TextDocumentPositionParams &
+WorkDoneProgressParams &
+PartialResultParams;
 
 type PublishDiagnosticsParams = {
-  diagnostics: Diagnostic[],
-  uri: DocumentURI,
-  version?: DocumentVersion,
+  diagnostics: Diagnostic[];
+  uri: DocumentURI;
+  version?: DocumentVersion;
+};
+
+type DocumentSymbolParams = {
+  textDocument: TextDocumentIdentifier;
 };
 
 type CommandParameters = {
-  [Commands.Completion]: CompletionParams,
-  [Commands.DocumentDidOpen]: DocumentDidOpenCommand,
-  [Commands.DocumentDidClose]: DocumentDidCloseCommand,
-  [Commands.DocumentDidChange]: DocumentDidChange,
-  [Commands.DocumentHover]: DocumentHover,
-  [Commands.Exit]: undefined,
-  [Commands.Definition] : DefinitionParams,
-  [Commands.PublishDiagnostics]: PublishDiagnosticsParams,
-  [Commands.Reference]: ReferenceParams,
-  [Commands.SemanticToken]: SemanticTokensParams,
-  [Commands.Shutdown]: undefined,
+  [Commands.Completion]: CompletionParams;
+  [Commands.DocumentDidOpen]: DocumentDidOpenCommand;
+  [Commands.DocumentDidClose]: DocumentDidCloseCommand;
+  [Commands.DocumentDidChange]: DocumentDidChange;
+  [Commands.DocumentHover]: DocumentHover;
+  [Commands.Exit]: undefined;
+  [Commands.Definition]: DefinitionParams;
+  [Commands.PublishDiagnostics]: PublishDiagnosticsParams;
+  [Commands.Reference]: ReferenceParams;
+  [Commands.SemanticToken]: SemanticTokensParams;
+  [Commands.Shutdown]: undefined;
+  [Commands.DocumentSymbol]: DocumentSymbolParams;
 };
 
 type CommandDefinitions = {
@@ -211,64 +215,64 @@ type CommandDefinitions = {
 
 type CommandResult = Record<string, unknown> | undefined;
 
-type ProtocolParams = DocumentDidOpenCommand
-| DocumentDidCloseCommand
-| DocumentDidChange
-| DocumentHover
-| SemanticTokensParams
-| DefinitionParams
-| ReferenceParams
-| CompletionParams
-| PublishDiagnosticsParams;
+type ProtocolParams =
+    | DocumentDidOpenCommand
+    | DocumentDidCloseCommand
+    | DocumentDidChange
+    | DocumentHover
+    | SemanticTokensParams
+    | DefinitionParams
+    | ReferenceParams
+    | CompletionParams
+    | PublishDiagnosticsParams;
 
-type ProtocolReturns = CompletionList | HoverCommandResponse;
+type ProtocolReturns =
+    | CompletionList
+    | HoverCommandResponse
+    | DocumentSymbolResponse;
 
 type EnvOptions = {
   lspServer?: {
     // Port of the LSP server
     // Env variable: PORT
     // Default: <none>
-    port?: number,
+    port?: number;
 
     // Host of the LSP Server
     // Env variable: LSP_SERVER_HOST
     // Default: localhost
-    host?: string,
+    host?: string;
 
     // Should the server be spawn ?
     // Accepted values are: 1, 0, on, off, true, false, yes, no
     // Env variable: SPAWN_LSP_SERVER
     // Default: false
-    spawn?: boolean,
+    spawn?: boolean;
 
     // Path to the server binary
     // If relative, it will be relative to the current folder
     // Env variable: RPC_SERVER_BIN
     // Default: <none>
-    binPath?: string,
+    binPath?: string;
 
     // Path to the schema.
     // If relative, it will be relative to the current folder
     // Env variable: SCHEMA_LOCATION
     // Default: <none>
-    jsonSchemaLocation?: string,
-  },
+    jsonSchemaLocation?: string;
+  };
 };
 
-export {
-  Commands,
-};
+export { Commands };
 
 export type {
   CommandDefinitions,
   CommandParameters,
   CommandResult,
   EnvOptions,
-
   Diagnostic,
   Position,
   Range,
-
   CompletionList,
   CompletionParams,
   DocumentDidOpenCommand,
@@ -277,6 +281,7 @@ export type {
   DocumentHover,
   DefinitionParams,
   HoverCommandResponse,
+  DocumentSymbolResponse,
   ReferenceParams,
   ProtocolParams,
   ProtocolReturns,

--- a/pkg/parser/yamlparser.go
+++ b/pkg/parser/yamlparser.go
@@ -54,6 +54,12 @@ func (doc *YamlDocument) ParseYAML(context *utils.LsContext, offset protocol.Pos
 
 			doc.VersionRange = doc.NodeToRange(child)
 
+		case "setup":
+			if doc.GetNodeText(valueNode) == "true" {
+				doc.Setup = true
+			}
+			doc.SetupRange = doc.NodeToRange(child)
+
 		case "orbs":
 			if valueNode != nil {
 				doc.OrbsRange = doc.NodeToRange(valueNode)
@@ -184,6 +190,7 @@ type YamlDocument struct {
 	Context        *utils.LsContext
 	SchemaLocation string
 
+	Setup              bool
 	Orbs               map[string]ast.Orb
 	LocalOrbs          []LocalOrb
 	Executors          map[string]ast.Executor
@@ -193,6 +200,7 @@ type YamlDocument struct {
 	PipelineParameters map[string]ast.Parameter
 	YamlAnchors        map[string]YamlAnchor
 
+	SetupRange              protocol.Range
 	OrbsRange               protocol.Range
 	ExecutorsRange          protocol.Range
 	CommandsRange           protocol.Range

--- a/pkg/parser/yamlparser.go
+++ b/pkg/parser/yamlparser.go
@@ -55,10 +55,11 @@ func (doc *YamlDocument) ParseYAML(context *utils.LsContext, offset protocol.Pos
 			doc.VersionRange = doc.NodeToRange(child)
 
 		case "setup":
-			if doc.GetNodeText(valueNode) == "true" {
+			text := strings.TrimSpace(doc.GetNodeText(valueNode))
+			if len(text) != 0 && text != "false" {
 				doc.Setup = true
-				doc.SetupRange = doc.NodeToRange(child)
 			}
+			doc.SetupRange = doc.NodeToRange(child)
 
 		case "orbs":
 			if valueNode != nil {

--- a/pkg/parser/yamlparser.go
+++ b/pkg/parser/yamlparser.go
@@ -57,8 +57,8 @@ func (doc *YamlDocument) ParseYAML(context *utils.LsContext, offset protocol.Pos
 		case "setup":
 			if doc.GetNodeText(valueNode) == "true" {
 				doc.Setup = true
+				doc.SetupRange = doc.NodeToRange(child)
 			}
-			doc.SetupRange = doc.NodeToRange(child)
 
 		case "orbs":
 			if valueNode != nil {

--- a/pkg/parser/yamlparser_test.go
+++ b/pkg/parser/yamlparser_test.go
@@ -321,16 +321,6 @@ jobs:
     steps:
       - run: echo "Hello world"`,
 			ExpectValue: false,
-			ExpectRange: protocol.Range{
-				Start: protocol.Position{
-					Line:      2,
-					Character: 0,
-				},
-				End: protocol.Position{
-					Line:      4,
-					Character: 14,
-				},
-			},
 		},
 	}
 

--- a/pkg/parser/yamlparser_test.go
+++ b/pkg/parser/yamlparser_test.go
@@ -269,6 +269,9 @@ func TestSetupKey(t *testing.T) {
 		ExpectRange protocol.Range
 		Name        string
 	}
+	// These tests represent the behaviour of the CCI product.
+	// You can see the different thing that have been tried on here:
+	// https://app.circleci.com/pipelines/github/circleci/devex-demo?branch=continuation-workflows
 	testCases := []TestCase{
 		{
 			Name: "Is true when set to true",
@@ -307,7 +310,7 @@ jobs:
 			ExpectValue: false,
 		},
 		{
-			Name: "Is false with any other value",
+			Name: "Is true with complex values",
 			Content: `version: 2.1
 
 setup:
@@ -320,7 +323,35 @@ jobs:
       - image: cimg/go:1.19.1
     steps:
       - run: echo "Hello world"`,
+			ExpectValue: true,
+			ExpectRange: protocol.Range{
+				Start: protocol.Position{
+					Line:      2,
+					Character: 0,
+				},
+				End: protocol.Position{
+					Line:      4,
+					Character: 14,
+				},
+			},
+		},
+		{
+			Name: "Is false when empty",
+			Content: `version: 2.1
+
+setup:
+
+jobs:
+  toto:
+    docker:
+      - image: cimg/go:1.19.1
+    steps:
+      - run: echo "Hello world"`,
 			ExpectValue: false,
+			ExpectRange: protocol.Range{
+				Start: protocol.Position{Line: 0x2, Character: 0x0},
+				End:   protocol.Position{Line: 0x2, Character: 0x6},
+			},
 		},
 	}
 

--- a/pkg/parser/yamlparser_test.go
+++ b/pkg/parser/yamlparser_test.go
@@ -261,3 +261,85 @@ orbs:
 	assert.True(t, yamlDocument.IsFromUnfetchableOrb("ccc/entity"))
 	assert.False(t, yamlDocument.IsFromUnfetchableOrb("slack/entity"))
 }
+
+func TestSetupKey(t *testing.T) {
+	type TestCase struct {
+		Content     string
+		ExpectValue bool
+		ExpectRange protocol.Range
+		Name        string
+	}
+	testCases := []TestCase{
+		{
+			Name: "Is true when set to true",
+			Content: `version: 2.1
+
+setup: true
+
+jobs:
+  toto:
+    docker:
+      - image: cimg/go:1.19.1
+    steps:
+      - run: echo "Hello world"`,
+			ExpectValue: true,
+			ExpectRange: protocol.Range{
+				Start: protocol.Position{
+					Line:      2,
+					Character: 0,
+				},
+				End: protocol.Position{
+					Line:      2,
+					Character: 11,
+				},
+			},
+		},
+		{
+			Name: "Is false when not set",
+			Content: `version: 2.1
+
+jobs:
+  toto:
+    docker:
+      - image: cimg/go:1.19.1
+    steps:
+      - run: echo "Hello world"`,
+			ExpectValue: false,
+		},
+		{
+			Name: "Is false with any other value",
+			Content: `version: 2.1
+
+setup:
+  complex:
+    values: 42
+
+jobs:
+  toto:
+    docker:
+      - image: cimg/go:1.19.1
+    steps:
+      - run: echo "Hello world"`,
+			ExpectValue: false,
+			ExpectRange: protocol.Range{
+				Start: protocol.Position{
+					Line:      2,
+					Character: 0,
+				},
+				End: protocol.Position{
+					Line:      4,
+					Character: 14,
+				},
+			},
+		},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.Name, func(t *testing.T) {
+			yamlDocument, err := parser.ParseFromContent([]byte(tt.Content), testHelpers.GetDefaultLsContext(), uri.File(""), protocol.Position{})
+			assert.Nil(t, err)
+			assert.Equal(t, tt.ExpectValue, yamlDocument.Setup)
+			assert.Equal(t, tt.ExpectRange, yamlDocument.SetupRange)
+		})
+	}
+}

--- a/pkg/services/documentSymbols/setup.go
+++ b/pkg/services/documentSymbols/setup.go
@@ -1,18 +1,21 @@
 package documentSymbols
 
 import (
+	"strconv"
+
 	"github.com/CircleCI-Public/circleci-yaml-language-server/pkg/parser"
+	"github.com/CircleCI-Public/circleci-yaml-language-server/pkg/utils"
 	"go.lsp.dev/protocol"
 )
 
 func resolveSetupSymbol(doc *parser.YamlDocument) (symbols []protocol.DocumentSymbol) {
-	if doc.Setup {
+	if !utils.IsDefaultRange(doc.SetupRange) {
 		symbols = append(symbols, protocol.DocumentSymbol{
-			Name:           "setup: true",
+			Name:           "Setup",
+			Kind:           protocol.SymbolKindBoolean,
+			Detail:         strconv.FormatBool(doc.Setup),
 			Range:          doc.SetupRange,
 			SelectionRange: doc.SetupRange,
-			Kind:           protocol.SymbolKindConstant,
-			Detail:         "Continuation workflow enabled",
 		})
 	}
 	return

--- a/pkg/services/documentSymbols/setup.go
+++ b/pkg/services/documentSymbols/setup.go
@@ -1,0 +1,19 @@
+package documentSymbols
+
+import (
+	"github.com/CircleCI-Public/circleci-yaml-language-server/pkg/parser"
+	"go.lsp.dev/protocol"
+)
+
+func resolveSetupSymbol(doc *parser.YamlDocument) (symbols []protocol.DocumentSymbol) {
+	if doc.Setup {
+		symbols = append(symbols, protocol.DocumentSymbol{
+			Name:           "setup: true",
+			Range:          doc.SetupRange,
+			SelectionRange: doc.SetupRange,
+			Kind:           protocol.SymbolKindConstant,
+			Detail:         "Continuation workflow enabled",
+		})
+	}
+	return
+}

--- a/pkg/services/documentSymbols/symbols.go
+++ b/pkg/services/documentSymbols/symbols.go
@@ -38,6 +38,11 @@ func SymbolsForDocument(document *parser.YamlDocument) []protocol.DocumentSymbol
 
 	symbols = append(
 		symbols,
+		resolveSetupSymbol(document)...,
+	)
+
+	symbols = append(
+		symbols,
 		resolveOrbSymbols(document)...,
 	)
 

--- a/test-files/.circleci/continuation.yml
+++ b/test-files/.circleci/continuation.yml
@@ -1,0 +1,23 @@
+version: 2.1
+
+setup: true
+
+orbs:
+  continuation: circleci/continuation@0.1.2
+
+jobs:
+  setup:
+    executor: continuation/default
+    steps:
+      - checkout
+      - run:
+          name: Generate config
+          command: |
+            ./generate-config > generated_config.yml
+      - continuation/continue:
+          configuration_path: generated_config.yml
+
+workflows:
+  setup:
+    jobs:
+      - setup


### PR DESCRIPTION
[Jira](https://circleci.atlassian.net/browse/DEVEX-1376)

# Description

`textDocument/documentSymbol` also returns the `setup` key.

![Capture d’écran 2023-10-12 à 17 05 55](https://github.com/CircleCI-Public/circleci-yaml-language-server/assets/26357621/0d71db8b-0bf7-40a8-8e7f-35d7fc919d1f)

# Implementation details

Add the `setup` information in the `YamlDocument` and use it in `documentSymbol`.

# How to validate

In a config file, write `setup: true` at the top level and make sure you see it in the outline. Put any other value for `setup` and make sure the `setup` do not change.