### PR TITLE
ci: only build macOS arm64 once

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -258,17 +258,6 @@ jobs:
                   name: Build for mac os intel
                   command:
                       sh -c "go build `~/project/scripts/ldflags.sh` -o ~/project/bin/darwin-amd64-lsp ./cmd/start_server/start_server.go"
-            - run:
-                  name: Build for macos arm64
-                  command: |
-                      export LDFLAGS=$(SUFFIX='-s -w' ~/project/scripts/ldflags.sh)
-                      export CGO_ENABLED=1
-                      export GOOS=darwin
-                      export GOARCH=arm64
-                      export FRAMEWORKS="$(xcrun --show-sdk-path)/System/Library/Frameworks"
-                      export CC="zig cc -target aarch64-macos -F$FRAMEWORKS"
-                      export CXX="zig c++ -target aarch64-macos -F$FRAMEWORKS"
-                      sh -c "go build $LDFLAGS -o ~/project/bin/darwin-arm64-lsp ./cmd/start_server/start_server.go"
             - store_artifacts:
                   path: ~/project/bin
             - persist_to_workspace:


### PR DESCRIPTION
# Description

Only build macOS arm64 binary in build macOS arm64 job.

# Implementation details

Following a copy-paste malfunction, the "build macOS x86_64" job built both x86_64 and arm64 architectures.

This PR fixes the config file.

# How to validate

The CI should run without errors after merging on main.

