### PR TITLE
feat: report errors from LSP methods to rollbar

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/Masterminds/semver v1.5.0
 	github.com/go-git/go-git/v5 v5.5.2
 	github.com/pkg/errors v0.9.1
+	github.com/rollbar/rollbar-go v1.4.5
 	github.com/segmentio/encoding v0.3.6
 	github.com/smacker/go-tree-sitter v0.0.0-20221031025734-03a9c97d8039
 	github.com/whilp/git-urls v1.0.0
@@ -31,7 +32,6 @@ require (
 	github.com/kr/pretty v0.3.0 // indirect
 	github.com/pjbgf/sha1cd v0.2.3 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/rollbar/rollbar-go v1.4.5 // indirect
 	github.com/sergi/go-diff v1.1.0 // indirect
 	github.com/skeema/knownhosts v1.1.0 // indirect
 	github.com/xanzy/ssh-agent v0.3.3 // indirect

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -39,6 +39,7 @@ func (server JSONRPCServer) commandHandler(_ context.Context, reply jsonrpc2.Rep
 
 	logErrorAndReply := func(ctx context.Context, result interface{}, err error) error {
 		if err != nil {
+			fmt.Printf("error calling %s: %s\n", req.Method(), err.Error())
 			rollbar.Log(rollbar.ERR, err)
 		}
 		return reply(ctx, result, err)

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -91,7 +91,7 @@ func (server JSONRPCServer) commandHandler(_ context.Context, reply jsonrpc2.Rep
 		return nil
 
 	default:
-		return jsonrpc2.MethodNotFoundHandler(server.ctx, logErrorAndReply, req)
+		return jsonrpc2.MethodNotFoundHandler(server.ctx, reply, req)
 	}
 }
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -37,53 +37,60 @@ func (server JSONRPCServer) commandHandler(_ context.Context, reply jsonrpc2.Rep
 		}
 	}()
 
+	logErrorAndReply := func(ctx context.Context, result interface{}, err error) error {
+		if err != nil {
+			rollbar.Log(rollbar.ERR, err)
+		}
+		return reply(ctx, result, err)
+	}
+
 	switch req.Method() {
 
 	case protocol.MethodInitialize:
-		return server.methods.Initialize(reply, req)
+		return server.methods.Initialize(logErrorAndReply, req)
 
 	case protocol.MethodWorkspaceExecuteCommand:
-		return server.methods.ExecuteCommand(reply, req)
+		return server.methods.ExecuteCommand(logErrorAndReply, req)
 
 	case protocol.MethodTextDocumentDidOpen:
-		return server.methods.DidOpen(reply, req)
+		return server.methods.DidOpen(logErrorAndReply, req)
 
 	case protocol.MethodTextDocumentDidClose:
-		return server.methods.DidClose(reply, req)
+		return server.methods.DidClose(logErrorAndReply, req)
 
 	case protocol.MethodTextDocumentDidChange:
-		return server.methods.DidChange(reply, req)
+		return server.methods.DidChange(logErrorAndReply, req)
 
 	case protocol.MethodTextDocumentHover:
-		return server.methods.Hover(reply, req)
+		return server.methods.Hover(logErrorAndReply, req)
 
 	case protocol.MethodSemanticTokensFull:
-		return server.methods.SemanticTokens(reply, req)
+		return server.methods.SemanticTokens(logErrorAndReply, req)
 
 	case protocol.MethodTextDocumentDefinition:
-		return server.methods.Definition(reply, req)
+		return server.methods.Definition(logErrorAndReply, req)
 
 	case protocol.MethodTextDocumentReferences:
-		return server.methods.References(reply, req)
+		return server.methods.References(logErrorAndReply, req)
 
 	case protocol.MethodTextDocumentCompletion:
-		return server.methods.Complete(reply, req)
+		return server.methods.Complete(logErrorAndReply, req)
 
 	case protocol.MethodTextDocumentCodeAction:
-		return server.methods.CodeAction(reply, req)
+		return server.methods.CodeAction(logErrorAndReply, req)
 
 	case protocol.MethodShutdown:
 		return reply(server.ctx, nil, nil)
 
 	case protocol.MethodTextDocumentDocumentSymbol:
-		return server.methods.DocumentSymbols(reply, req)
+		return server.methods.DocumentSymbols(logErrorAndReply, req)
 
 	case protocol.MethodExit:
 		os.Exit(0)
 		return nil
 
 	default:
-		return jsonrpc2.MethodNotFoundHandler(server.ctx, reply, req)
+		return jsonrpc2.MethodNotFoundHandler(server.ctx, logErrorAndReply, req)
 	}
 }
 


### PR DESCRIPTION
# Description

This PR will report errors from LSP methods to rollbar.

# Implementation details

Implemented using a "middleware" style. It takes the "replier" function provided by the JSON RPC server, and wraps in a same-signature function, checking for an error, before reporting it to rollbar and passing it on to the original replier.


