### PR TITLE
feat: documentSymbols returns an error if file does not exist

### DIFF
--- a/pkg/services/documentSymbols.go
+++ b/pkg/services/documentSymbols.go
@@ -2,6 +2,8 @@ package languageservice
 
 import (
 	"errors"
+	"fmt"
+	"os"
 
 	yamlparser "github.com/CircleCI-Public/circleci-yaml-language-server/pkg/parser"
 	"github.com/CircleCI-Public/circleci-yaml-language-server/pkg/services/documentSymbols"
@@ -9,7 +11,46 @@ import (
 	"go.lsp.dev/protocol"
 )
 
+func uriPath(uri protocol.URI) (path string, err error) {
+	defer func() {
+		panicErr := recover()
+		if panicErr != nil {
+			path = ""
+
+			var ok bool
+			if err, ok = panicErr.(error); ok {
+				return
+			}
+
+			err = fmt.Errorf("%s", panicErr)
+			return
+		}
+	}()
+	path = uri.Filename()
+	return
+}
+
 func DocumentSymbols(params protocol.DocumentSymbolParams, cache *utils.Cache, context *utils.LsContext) ([]protocol.DocumentSymbol, error) {
+	path, err := uriPath(params.TextDocument.URI)
+	if err != nil {
+		return nil, err
+	}
+
+	exists := true
+	_, err = os.Stat(path)
+	if err != nil {
+		if !errors.Is(err, os.ErrNotExist) {
+			// Error is not "file does not exist", stop execution and return
+			return nil, err
+		}
+		exists = false
+	}
+
+	if !exists {
+		cache.FileCache.RemoveFile(params.TextDocument.URI)
+		return nil, fmt.Errorf("file does not exist: %w", err)
+	}
+
 	yamlDocument, err := yamlparser.ParseFromUriWithCache(params.TextDocument.URI, cache, context)
 
 	if errors.Is(err, yamlparser.CacheMissingError) {


### PR DESCRIPTION
[Jira](https://circleci.atlassian.net/browse/DEVEX-1325)

# Description

When the LS receives a `documentSymbols` request, and the file does not exist, return an error to the client.

# Implementation details

When the server receives a `documentSymbols` request, it checks that the file exists. If not, it returns an error, optionally removing the file from the cache.

There is also a small helper function that wraps `URI.Filename`, so that it recovers from a possible panic and returns an error instead.


