### PR TITLE
fix: detect orb used in job parameters

### DIFF
--- a/pkg/parser/validate/orb.go
+++ b/pkg/parser/validate/orb.go
@@ -169,6 +169,10 @@ func (val Validate) checkIfOrbIsUsed(orb ast.Orb) bool {
 			if val.checkIfStepsContainOrb(steps, orb.Name) {
 				return true
 			}
+
+			if val.checkIfJobParamContainOrb(jobRef.Parameters, orb.Name) {
+				return true
+			}
 		}
 	}
 

--- a/pkg/parser/validate/orb_test.go
+++ b/pkg/parser/validate/orb_test.go
@@ -1,9 +1,11 @@
 package validate
 
 import (
+	"os"
 	"testing"
 
 	"github.com/CircleCI-Public/circleci-yaml-language-server/pkg/utils"
+	"github.com/stretchr/testify/assert"
 	"go.lsp.dev/protocol"
 )
 
@@ -256,4 +258,16 @@ workflows:
 	}
 
 	CheckYamlErrors(t, testCases)
+}
+
+func TestOrbStepsUsedInParameters(t *testing.T) {
+	content, err := os.ReadFile("testdata/orb_steps_used_in_params.yml")
+	assert.NoError(t, err)
+	val := CreateValidateFromYAML(string(content))
+	val.Validate(false)
+	for _, diag := range *val.Diagnostics {
+		if diag.Message == "Orb is unused" {
+			t.Errorf("Got orb is unused diagnostic")
+		}
+	}
 }

--- a/pkg/parser/validate/steps.go
+++ b/pkg/parser/validate/steps.go
@@ -166,6 +166,38 @@ func (val Validate) checkIfStepsContainOrb(steps []ast.Step, orbName string) boo
 	return false
 }
 
+func (val Validate) checkIfJobParamContainOrb(params map[string]ast.ParameterValue, orbName string) bool {
+	for _, p := range params {
+		array, ok := p.Value.([]ast.ParameterValue)
+		if !ok {
+			continue
+		}
+
+		for _, value := range array {
+			if value.Type != "steps" {
+				break
+			}
+
+			steps, ok := value.Value.([]ast.Step)
+			if !ok {
+				continue
+			}
+
+			for _, step := range steps {
+				name := step.GetName()
+				split := strings.Split(name, "/")
+				if len(split) != 2 {
+					continue
+				}
+				if split[0] == orbName {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}
+
 func (val Validate) checkIfJobUseOrb(job ast.Job, orbName string) bool {
 	if val.checkIfStepsContainOrb(job.Steps, orbName) {
 		return true

--- a/pkg/parser/validate/testdata/orb_steps_used_in_params.yml
+++ b/pkg/parser/validate/testdata/orb_steps_used_in_params.yml
@@ -1,0 +1,27 @@
+version: 2.1
+
+orbs:
+  slack: circleci/slack@4.10.1
+
+jobs:
+  run-steps:
+    parameters:
+      custom-steps:
+        type: steps
+        default: []
+    docker:
+      - image: cimg/node:18.18.1
+    steps:
+      - steps: << parameters.custom-steps >>
+
+workflows:
+  workflow:
+    jobs:
+      - run-steps:
+          custom-steps:
+            - slack/notify:
+                custom: ""
+                event: always
+            - slack/notify:
+                custom: "toto"
+                event: always


### PR DESCRIPTION
Jira ticket: none

# Description

Addresses https://github.com/CircleCI-Public/circleci-yaml-language-server/issues/218. The issue is that when orb commands are used in a job `steps` parameters, we still consider the orb as unused.

# Implementation details

Loop over jobs parameters to see if their parameters use the orb.

# How to validate

You can open a file that reproduce the situation in `pkg/parser/validate/testdata/orb_steps_used_in_params.yml` and make sure you get no warning.