### PR TITLE
fix: do not remove files that do not exist on disk from `FileCache`

### DIFF
--- a/pkg/services/documentSymbols.go
+++ b/pkg/services/documentSymbols.go
@@ -2,8 +2,6 @@ package languageservice
 
 import (
 	"errors"
-	"fmt"
-	"os"
 
 	yamlparser "github.com/CircleCI-Public/circleci-yaml-language-server/pkg/parser"
 	"github.com/CircleCI-Public/circleci-yaml-language-server/pkg/services/documentSymbols"
@@ -11,46 +9,7 @@ import (
 	"go.lsp.dev/protocol"
 )
 
-func uriPath(uri protocol.URI) (path string, err error) {
-	defer func() {
-		panicErr := recover()
-		if panicErr != nil {
-			path = ""
-
-			var ok bool
-			if err, ok = panicErr.(error); ok {
-				return
-			}
-
-			err = fmt.Errorf("%s", panicErr)
-			return
-		}
-	}()
-	path = uri.Filename()
-	return
-}
-
 func DocumentSymbols(params protocol.DocumentSymbolParams, cache *utils.Cache, context *utils.LsContext) ([]protocol.DocumentSymbol, error) {
-	path, err := uriPath(params.TextDocument.URI)
-	if err != nil {
-		return nil, err
-	}
-
-	exists := true
-	_, err = os.Stat(path)
-	if err != nil {
-		if !errors.Is(err, os.ErrNotExist) {
-			// Error is not "file does not exist", stop execution and return
-			return nil, err
-		}
-		exists = false
-	}
-
-	if !exists {
-		cache.FileCache.RemoveFile(params.TextDocument.URI)
-		return nil, fmt.Errorf("file does not exist: %w", err)
-	}
-
 	yamlDocument, err := yamlparser.ParseFromUriWithCache(params.TextDocument.URI, cache, context)
 
 	if errors.Is(err, yamlparser.CacheMissingError) {


### PR DESCRIPTION
Jira ticket: None

# Description

Because `FileCache` is actually not a cache but holding the state of the VSCode buffer, we must **not** delete the file in the `FileCache` when the cache does not exist on disk.

# Implementation details

This reverts commit 5541d4a4c2ae38c04af75beec8ddc72ccc7397d7.

# How to validate

> Add steps to setup the extension and check that the PR works

