### PR TITLE
ci: upgrade gh cli to 2.37.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -378,7 +378,8 @@ jobs:
       docker:
         - image: cimg/node:18.16
       steps:
-        - github-cli/install
+        - github-cli/install:
+            version: '2.37.0'
         - node/install-yarn
         - checkout
         - run:
@@ -450,7 +451,8 @@ jobs:
         docker:
             - image: cimg/base:stable
         steps:
-            - github-cli/install
+            - github-cli/install:
+                version: '2.37.0'
             - attach_workspace:
                 at: ~/
             - run:
@@ -549,7 +551,8 @@ jobs:
             name: Halt job if running pipeline from a fork
             command: |
               [ -z $CIRCLE_PR_NUMBER ] || circleci-agent step halt
-        - github-cli/install
+        - github-cli/install:
+            version: '2.37.0'
         - checkout
         - run:
             name: Assign PR to author


### PR DESCRIPTION
# Description

Our ci currently uses an outdated version of `gh` and a lot of flags and commands we use for releasing are not available.
This PR forces the orb `circleci/github-cli` to install the currently latest github cli version `2.37.0`.