### PR TITLE
fix: add support for xcode version 15.0.0

### DIFF
--- a/pkg/parser/validate/executor.go
+++ b/pkg/parser/validate/executor.go
@@ -39,6 +39,7 @@ func (val Validate) validateSingleExecutor(executor ast.Executor) {
 // MacOSExecutor
 
 var ValidXCodeVersions = []string{
+	"15.0.0",
 	"14.3.1",
 	"14.2.0",
 	"14.1.0",


### PR DESCRIPTION
[Jira](https://circleci.atlassian.net/browse/XXXX-1234)

# Description

add support for xcode version 15.0.0

# Implementation details

update list of xcode versions

# How to validate

test a config file with xcode version 15.0.0
```
version: 2.1

executors:
  mac:
    macos:
      xcode: 15.0.0
    environment:
      CGO_ENABLED: 0
      HOMEBREW_NO_AUTO_UPDATE: 1
      TERM: xterm-256color
