### PR TITLE
ci: split the workflows

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -176,7 +176,7 @@ commands:
 jobs:
     Create version file:
         docker:
-            - image: cimg/base:2023.11
+            - image: cimg/go:1.21.4
         description: |
             Create a version to be used by the /scripts/ldflags.sh when building the binaries
         parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -174,6 +174,39 @@ commands:
               }
 
 jobs:
+    Create version file:
+        docker:
+            - image: cimg/base:2023.11
+        description: |
+            Create a version to be used by the /scripts/ldflags.sh when building the binaries
+        parameters:
+            is-prerelease:
+                type: boolean
+                description: |
+                    When set to true will set a prerelease in the version file.
+                    Else will set the version from the release-please manifest
+        steps:
+            - when:
+                condition: << parameters.is-prerelease >>
+                steps:
+                    - run:
+                        name: Write the pre-release version in the version file
+                        command: |
+                            go run ~/project/scripts/get_next_release.go > ~/version
+            - when:
+                condition:
+                    not: << parameters.is-prerelease >>
+                steps:
+                    - run:
+                        name: Write the next release version in the version file
+                        command: |
+                            version=$(jq -r '.["."]' ~/project/.circleci/release/release-please-manifest.json)
+                            echo "export VERSION=$version" > ~/version
+            - persist_to_workspace:
+                root: ~/
+                paths:
+                    - ~/version
+
     Unit Tests:
         environment:
             SCHEMA_LOCATION: /home/circleci/project/schema.json
@@ -196,6 +229,8 @@ jobs:
         docker:
             - image: cimg/go:1.19.1
         steps:
+            - attach_workspace:
+                at: ~/
             - checkout
             - run:
                   name: Build for Linux Amd 64
@@ -212,6 +247,8 @@ jobs:
         docker:
             - image: cimg/go:1.19.1
         steps:
+            - attach_workspace:
+                at: ~/
             - checkout
             - install-zig
             - run:
@@ -238,6 +275,8 @@ jobs:
         environment:
             HOMEBREW_NO_AUTO_UPDATE: 1
         steps:
+            - attach_workspace:
+                at: ~/
             - checkout
             - run: brew install golang
             - run: brew install zig
@@ -258,6 +297,8 @@ jobs:
         environment:
             HOMEBREW_NO_AUTO_UPDATE: 1
         steps:
+            - attach_workspace:
+                at: ~/
             - checkout
             - run: brew install golang
             - run: brew install zig
@@ -283,6 +324,8 @@ jobs:
         docker:
             - image: cimg/go:1.19.1
         steps:
+            - attach_workspace:
+                at: ~/
             - checkout
             - install-zig
             - run:
@@ -353,10 +396,6 @@ jobs:
             - image: cimg/go:1.19.1
         steps:
             - checkout
-            - node/install:
-                node-version: '18'
-            - node/install-yarn
-            - install-vscode-extensions-deps
             - run:
                 name: Linter check for Go
                 command: if [[ $(gofmt -l pkg | wc -c) -ne 0 ]]; then exit 1; fi
@@ -538,54 +577,45 @@ jobs:
             command: |
               gh pr edit --add-assignee $(gh pr view --json author --jq .author.login)
 
-
 workflows:
-    Build and release:
+    Release PR:
+        when: &release-conditions
+            or:
+                - equal:
+                    - << pipeline.git.branch >>
+                    - main
+                - matches:
+                    value: << pipeline.git.branch >>
+                    pattern: ^hotfix.*$
+        jobs:
+            - Prepare release:
+                name: Create/update release PR
+                context:
+                    - devex-release
+
+    Build and prerelease:
+        when: *release-conditions
         jobs:
             - Unit Tests
-            - Lint:
-                filters:
-                  branches:
-                    ignore: &release-branches
-                        - main
-                        - /^hotfix.*/
-            - Security Scan release:
-                name: Security Scan (main/hotfix)
-                filters:
-                  branches:
-                    only: *release-branches
-                context:
-                    - devex-release
-                    - org-global-employees
-            - Security Scan feature:
-                name: Security Scan (feature)
-                filters:
-                  branches:
-                    ignore: *release-branches
-                context:
-                    - devex-release
-                    - org-global-employees
-            - Build Linux x86_64
+            - Security Scan release
+            - Copy JSON schema
+            - Create version file:
+                is-prerelease: true
+            - Build Linux x86_64:
+                requires:
+                    - Create version file
             - Build Linux arm64:
-                filters:
-                  branches:
-                    only: *release-branches
+                requires:
+                    - Create version file
             - Build MacOS x86_64:
-                filters:
-                  branches:
-                    only: *release-branches
+                requires:
+                    - Create version file
             - Build MacOS arm64:
-                filters:
-                  branches:
-                    only: *release-branches
+                requires:
+                    - Create version file
             - Build Windows:
-                filters:
-                  branches:
-                    only: *release-branches
-            - Copy JSON schema:
-                filters:
-                  branches:
-                    only: *release-branches
+                requires:
+                    - Create version file
             - Build VSIX:
                 requires:
                     - Build Linux x86_64
@@ -594,14 +624,9 @@ workflows:
                     - Build MacOS arm64
                     - Build Windows
                     - Copy JSON schema
-                filters:
-                    branches:
-                        only: *release-branches
             - Pre-Release:
-                filters:
-                    branches:
-                        only: *release-branches
                 requires:
+                    - Security Scan release
                     - Unit Tests
                     - Build Linux x86_64
                     - Build Linux arm64
@@ -611,72 +636,79 @@ workflows:
                     - Copy JSON schema
                 context:
                     - devex-release
-            - Github Release:
-                filters:
-                  branches:
-                    only: *release-branches
-                context:
-                    - devex-release
-                requires:
-                    - Unit Tests
-                    - Build Linux x86_64
-                    - Build Linux arm64
-                    - Build MacOS x86_64
-                    - Build MacOS arm64
-                    - Build Windows
-                    - Copy JSON schema
 
-    Release PR:
+    Build and release:
+        when: *release-conditions
         jobs:
-            - Prepare release:
-                name: Create/update release PR
-                filters:
-                    branches:
-                        only: *release-branches
+            - Unit Tests
+            - Security Scan release
+            - Copy JSON schema
+            - Create version file:
+                is-prerelease: false
+            - Build Linux x86_64:
+                requires:
+                    - Create version file
+            - Build Linux arm64:
+                requires:
+                    - Create version file
+            - Build MacOS x86_64:
+                requires:
+                    - Create version file
+            - Build MacOS arm64:
+                requires:
+                    - Create version file
+            - Build Windows:
+                requires:
+                    - Create version file
+            - Build VSIX:
+                requires:
+                    - Build Linux x86_64
+                    - Build Linux arm64
+                    - Build MacOS x86_64
+                    - Build MacOS arm64
+                    - Build Windows
+                    - Copy JSON schema
+            - Github Release:
+                requires:
+                    - Security Scan release
+                    - Unit Tests
+                    - Build Linux x86_64
+                    - Build Linux arm64
+                    - Build MacOS x86_64
+                    - Build MacOS arm64
+                    - Build Windows
+                    - Copy JSON schema
+                context:
+                    - devex-release
+            - Upload artifacts:
+                requires:
+                    - Github Release
                 context:
                     - devex-release
 
     Feature PR:
+        when:
+            not: *release-conditions
         jobs:
             - Lint PR title:
-                filters:
-                    branches:
-                        ignore: *release-branches
                 context:
                   - devex-release
             - Auto-assign PR:
-                filters:
-                    branches:
-                        ignore: *release-branches
                 context:
                   - devex-release
 
-    Undraft release:
+    Build and test:
+        when:
+            not: *release-conditions
         jobs:
-            - Build Linux x86_64:
-                filters: &release-tag-filters
-                    branches:
-                        ignore: /.*/
-                    tags:
-                        only: /\d+\.\d+\.\d+/
-            - Build Linux arm64:
-                filters: *release-tag-filters
-            - Build MacOS x86_64:
-                filters: *release-tag-filters
-            - Build MacOS arm64:
-                filters: *release-tag-filters
-            - Build Windows:
-                filters: *release-tag-filters
-            - Copy JSON schema:
-                filters: *release-tag-filters
-            - Upload artifacts:
-                filters: *release-tag-filters
-                requires:
-                    - Build Linux x86_64
-                    - Build Linux arm64
-                    - Build MacOS x86_64
-                    - Build MacOS arm64
-                    - Build Windows
-                    - Copy JSON schema
+            - Unit Tests
+            - Security Scan feature:
                 context:
-                  - devex-release
+                    - devex-release
+                    - org-global-employees
+            - Lint
+            - Create version file:
+                is-prerelease: true
+            - Build Linux x86_64:
+                requires:
+                    - Create version file

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -186,6 +186,7 @@ jobs:
                     When set to true will set a prerelease in the version file.
                     Else will set the version from the release-please manifest
         steps:
+            - checkout
             - when:
                 condition: << parameters.is-prerelease >>
                 steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -205,7 +205,7 @@ jobs:
             - persist_to_workspace:
                 root: ~/
                 paths:
-                    - ~/version
+                    - version
 
     Unit Tests:
         environment:

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -33,7 +33,6 @@ tasks:
       - task: build:do
         vars:
           BIN_PATH: bin/start_server
-          BUILD_FLAGS: $(./scripts/ldflags.sh)
           GO_FILE: cmd/start_server/start_server.go
 
   build:server:debug:
@@ -42,7 +41,7 @@ tasks:
       - task: build:do
         vars:
           BIN_PATH: bin/start_server
-          BUILD_FLAGS: $(./scripts/ldflags.sh) -gcflags='all=-N -l'
+          BUILD_FLAGS: -gcflags='all=-N -l'
           GO_FILE: cmd/start_server/start_server.go
 
   build:test-tree-sitter:

--- a/scripts/get_next_release.go
+++ b/scripts/get_next_release.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"os"
 	"regexp"
 	"strconv"
 
@@ -13,17 +12,8 @@ import (
 )
 
 func main() {
-	tag := getTag()
+	tag := getNextPrereleaseTag()
 	fmt.Println(tag)
-}
-
-func getTag() string {
-	// CIRCLE_TAG is a built-in environment variable documented here: https://circleci.com/docs/variables/
-	tag, hasTag := os.LookupEnv("CIRCLE_TAG")
-	if hasTag {
-		return tag
-	}
-	return getNextPrereleaseTag()
 }
 
 func getNextPrereleaseTag() string {

--- a/scripts/ldflags.sh
+++ b/scripts/ldflags.sh
@@ -1,13 +1,16 @@
 #!/usr/bin/env bash
 # Inspired by https://belief-driven-design.com/build-time-variables-in-go-51439b26ef9/
 
+if [ ! -f ~/version ];
+then
+	>&2 echo "No version file defined. Returning invalid build argument"
+	echo "invalid-argument"
+	exit 1
+fi
 
 PACKAGE="github.com/CircleCI-Public/circleci-yaml-language-server/pkg/utils"
 
-SCRIPT_PATH=$(cd $(dirname $0) && pwd)
-VERSION=$(cd $SCRIPT_PATH && go run ./get_next_release.go)
-
-BUILD_TIMESTAMP=$(date '+%Y-%m-%dT%H:%M:%S')
+VERSION=$(cat ~/version)
 
 LDFLAGS=(
   "-X '${PACKAGE}.ServerVersion=${VERSION}'"


### PR DESCRIPTION
Jira ticket: None

# Description

The different workflows used are now split into several workflows. The release and the prerelease happen in different workflows.

# Implementation details

There is now workflows just for the feature PRs and workflows just for the release PRs. Amongst the release PR workflows, one of them does the pre-release and one of them does the release.
The workflows are filtered with the `when` instruction at the workflow level.

# How to validate

Most of it will have to be validated on the next release.
