### PR TITLE
fix: error when passing an enum to a string param

### DIFF
--- a/pkg/parser/validate/parameters.go
+++ b/pkg/parser/validate/parameters.go
@@ -115,7 +115,9 @@ func (val Validate) checkParamUsedWithParam(param ast.ParameterValue, stepName s
 		// check already done before in `CheckIfParamsExist`
 		return
 	}
-	if (!(definedParam.GetType() == "string" && paramUsedAsValue.GetType() == "enum")) && (paramUsedAsValue.GetType() != definedParam.GetType()) {
+	definedType := definedParam.GetType()
+	valueType := paramUsedAsValue.GetType()
+	if definedType != valueType && !(definedType == "string" && valueType == "enum") { // String params can accept "string" or "enum"
 		val.createParameterError(param, stepName, definedParam.GetType())
 	}
 }

--- a/pkg/parser/validate/parameters.go
+++ b/pkg/parser/validate/parameters.go
@@ -115,8 +115,7 @@ func (val Validate) checkParamUsedWithParam(param ast.ParameterValue, stepName s
 		// check already done before in `CheckIfParamsExist`
 		return
 	}
-
-	if paramUsedAsValue.GetType() != definedParam.GetType() {
+	if (!(definedParam.GetType() == "string" && paramUsedAsValue.GetType() == "enum")) && (paramUsedAsValue.GetType() != definedParam.GetType()) {
 		val.createParameterError(param, stepName, definedParam.GetType())
 	}
 }


### PR DESCRIPTION
[Jira](https://circleci.atlassian.net/browse/XXXX-1234)

# Description

False “parameter must be a string” error when passing an enum

# Implementation details

Avoid creating an error when passed parameter type is enum and definition is string

# How to validate

test config file 

```
version: 2.1

orbs:
  android: circleci/android@2.3.0

commands:

  stringeater-choking-on-enums:
    parameters:
      string-parameter:
        type: string
    steps:
      - run: echo "do nothing"

jobs:
  parametric-job:
    resource_class: large
    docker:
      - image: cimg/android:2021.12.2-node
    parameters:
      enum-parameter:
        type: enum
        default: apple
        enum:
          - apple
          - orange
    steps:
      - store_artifacts:
          path: << parameters.enum-parameter >>
      - stringeater-choking-on-enums:
          string-parameter: << parameters.enum-parameter >>
      - stringeater-choking-on-enums:
          string-parameter: << parameters.enum-parameter >> ""
      - android/fastlane-deploy:
          lane-name: << parameters.enum-parameter >>

workflows:
  build:
    jobs:
      - parametric-job:
          enum-parameter: apple
      - parametric-job:
          enum-parameter: orange```
