### PR TITLE
fix: send diagnostics when config couldn't be parsed

### DIFF
--- a/pkg/services/diagnostics.go
+++ b/pkg/services/diagnostics.go
@@ -48,7 +48,7 @@ func DiagnosticString(content string, cache *utils.Cache, context *utils.LsConte
 }
 
 func DiagnosticYAML(yamlDocument yamlparser.YamlDocument, cache *utils.Cache, context *utils.LsContext) ([]protocol.Diagnostic, error) {
-	if yamlDocument.Version < 2.1 {
+	if yamlDocument.Version != 0 && yamlDocument.Version < 2.1 {
 		// TODO: Handle error
 		return []protocol.Diagnostic{}, nil
 	}


### PR DESCRIPTION
[Jira](https://circleci.atlassian.net/jira/software/c/projects/DEVEX/issues/DEVEX-1274)

# Description

Send Diagnostics when config is not parsed

# Implementation details

Don't send empty diagnostics when yaml version is 0

# How to validate

test a config file attached to the ticket

