### PR TITLE
fix: go to definition for local orbs were not working

### DIFF
--- a/pkg/ast/orb.go
+++ b/pkg/ast/orb.go
@@ -47,6 +47,7 @@ type OrbInfo struct {
 }
 
 type OrbParsedAttributes struct {
+	URI  protocol.URI
 	Name string
 
 	Commands           map[string]Command

--- a/pkg/parser/local_orb.go
+++ b/pkg/parser/local_orb.go
@@ -69,6 +69,7 @@ func (doc *YamlDocument) parseLocalOrb(name string, orbNode *sitter.Node, adding
 		Source:      orbContent,
 		Description: orbDoc.Description,
 		OrbParsedAttributes: ast.OrbParsedAttributes{
+			URI:  doc.URI,
 			Name: name,
 
 			Commands:           orbDoc.Commands,

--- a/pkg/parser/yamlparser.go
+++ b/pkg/parser/yamlparser.go
@@ -629,6 +629,7 @@ func (doc *YamlDocument) ToOrbParsedAttributes() ast.OrbParsedAttributes {
 
 func (doc *YamlDocument) FromOrbParsedAttributesToYamlDocument(orb ast.OrbParsedAttributes) YamlDocument {
 	return YamlDocument{
+		URI:          orb.URI,
 		LocalOrbName: orb.Name,
 
 		RootNode: doc.RootNode,


### PR DESCRIPTION
Jira: None

# Description

Go to definition in local orb, targeting other local orb elements was opening a folder instead of making the `Go to definition`.

# Implementation details

The issue is actually that local orbs don't know which `yaml` they're coming from, so when asked for definition, they give `<empty string>` and the editor thus try opening the actual directory.
To fix that, the `URI` field has been added to local orbs and it is passed when making `Go to definition`.

# How to validate

Tests have been added but you can try this yourself by declaring a local orb with executor(s), command(s) and job(s). Have jobs use the local orb's executors or commands and try making go to definition on those to make sure it point to the right point.