### PR TITLE
fix: Latest Xcode versions

### DIFF
--- a/pkg/parser/validate/executor.go
+++ b/pkg/parser/validate/executor.go
@@ -39,6 +39,8 @@ func (val Validate) validateSingleExecutor(executor ast.Executor) {
 // MacOSExecutor
 
 var ValidXCodeVersions = []string{
+	"15.3.0",
+	"15.2.0",
 	"15.1.0",
 	"15.0.0",
 	"14.3.1",


### PR DESCRIPTION

# Description

>  Updated executor parser to accept latest Xcode versions available.

https://circleci.com/docs/using-macos/#supported-xcode-versions-silicon

# Implementation details

> Added `"15.3.0"` and `"15.2.0"` to the `ValidXCodeVersions` array

# How to validate

> Add an executor with Xcode version 15.2.0 / 15.3.0 like so

```yml
executors:
  myX:
    macos:
      xcode: 15.2.0
    resource_class: macos.m1.medium.gen1
```

