### PR TITLE
docs: add documentation on implementing clients

### DIFF
--- a/ADD_A_CLIENT.md
+++ b/ADD_A_CLIENT.md
@@ -8,9 +8,9 @@ aware of.
 
 ### `schema.json`
 
-The Language Server needs the [`schema.json`](/schema.json) to validate the
-YAMLs. To run the LS, you must have the file available locally and provide its
-path to the `-schema` parameter of the LS.
+The Language Server (LS) needs the [`schema.json`](/schema.json) file to
+validate the YAMLs. To run the LS, you must have the file available locally and
+provide its path as `-schema` argument to the LS executable.
 
 As the `schema.json` is versioned like the rest of the code, it is provided with
 every release, this means that when updating the LS binary should always come
@@ -18,28 +18,30 @@ with an update of the `schema.json`.
 
 ### Hover
 
-The `hover` functionality is not actually implemented by the LS. Nevertheless,
-you will see reference to the functionality as it is implemented directly in the
-Typescript code of the VSCode extension. The functionality is provided thanks to
-the
+The
+[`textDocument/hover`](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_hover)
+functionality is not actually implemented by the LS. Nevertheless, you will see
+reference to the functionality as it is implemented directly in the Typescript
+code of the VSCode extension. The functionality is provided thanks to the
 [SchemaStore JSON schema for CircleCI configs](https://github.com/SchemaStore/schemastore/blob/master/src/schemas/json/circleciconfig.json)
 that CircleCI help maintain and the
 [vscode-json-languageservice](https://github.com/microsoft/vscode-json-languageservice).
 
 If you plan on implementing the feature you should look for a way to take
 advantage of this JSON and find an equivalent of `vscode-json-languageservice`
-that work for your editor.
+that works for your editor.
 
 ### Configuration
 
-To be able to better handle the usage of private orbs, self-hosted runners or
-even contexts you can authenticate to the Language Server with custom LS
-commands.
+To better handle the usage of private orbs, self-hosted runners or even contexts
+you can authenticate to the Language Server with custom LS commands.
 
 ##### `setToken`
 
-The `setToken` command takes an API token as only argument. Users can get API
-token from [here](https://app.circleci.com/settings/user/tokens).
+The `setToken` command takes a CircleCI API token as only argument. Users can
+get API token from
+[User settings](https://app.circleci.com/settings/user/tokens) in the CircleCI
+app.
 
 Example Typescript usage:
 
@@ -52,8 +54,8 @@ await lsClient.sendRequest(`workspace/executeCommand`, {
 
 ##### `setSelfHostedUrl`
 
-For users using the [Server](https://circleci.com/pricing/server/) version of
-CircleCI, you can set the URL of the self-hosted Server with this command.
+For users using [CircleCI Server](https://circleci.com/pricing/server/), you can
+set the URL of the self-hosted Server with this command.
 
 Example Typescript usage:
 

--- a/ADD_A_CLIENT.md
+++ b/ADD_A_CLIENT.md
@@ -1,0 +1,65 @@
+# Add a client
+
+Implementations of Language Server clients are always welcome, if you happen to
+create one, please open an issue so that we can
+[reference your work](/README.md#language-server-clients)! However please read
+this document before starting implementation as there are some specifities to be
+aware of.
+
+### `schema.json`
+
+The Language Server needs the [`schema.json`](/schema.json) to validate the
+YAMLs. To run the LS, you must have the file available locally and provide its
+path to the `-schema` parameter of the LS.
+
+As the `schema.json` is versioned like the rest of the code, it is provided with
+every release, this means that when updating the LS binary should always come
+with an update of the `schema.json`.
+
+### Hover
+
+The `hover` functionality is not actually implemented by the LS. Nevertheless,
+you will see reference to the functionality as it is implemented directly in the
+Typescript code of the VSCode extension. The functionality is provided thanks to
+the
+[SchemaStore JSON schema for CircleCI configs](https://github.com/SchemaStore/schemastore/blob/master/src/schemas/json/circleciconfig.json)
+that CircleCI help maintain and the
+[vscode-json-languageservice](https://github.com/microsoft/vscode-json-languageservice).
+
+If you plan on implementing the feature you should look for a way to take
+advantage of this JSON and find an equivalent of `vscode-json-languageservice`
+that work for your editor.
+
+### Configuration
+
+To be able to better handle the usage of private orbs, self-hosted runners or
+even contexts you can authenticate to the Language Server with custom LS
+commands.
+
+##### `setToken`
+
+The `setToken` command takes an API token as only argument. Users can get API
+token from [here](https://app.circleci.com/settings/user/tokens).
+
+Example Typescript usage:
+
+```typescript
+await lsClient.sendRequest(`workspace/executeCommand`, {
+  command: 'setToken',
+  arguments: ['<user-token>'],
+});
+```
+
+##### `setSelfHostedUrl`
+
+For users using the [Server](https://circleci.com/pricing/server/) version of
+CircleCI, you can set the URL of the self-hosted Server with this command.
+
+Example Typescript usage:
+
+```typescript
+await lsClient.sendRequest(`workspace/executeCommand`, {
+  command: 'setSelfHostedUrl',
+  arguments: ['<self-hosted-url>'],
+});
+```

--- a/README.md
+++ b/README.md
@@ -38,17 +38,17 @@ server that handles different calls (specified by the LSP spec).
 
 ## Summary
 
--   [Features](./README.md#features)
--   [Platforms, Deployment and Package Managers](./README.md#platforms)
--   [Contributing](./README.md#contributing)
--   [Architecture Diagram](./README.md#architecture)
--   [Code of Conduct](./CODE_OF_CONDUCT.md)
--   [Contribution Guidelines](./CONTRIBUTING.md)
--   [Contributors](./README.md#contributor)
--   [Quick Links](./README.md#quicklinks)
--   [Credits](./README.md#credits)
--   [Hacking](./HACKING.md)
--   [License](./README.md#licence)
+- [Features](./README.md#features)
+- [Platforms, Deployment and Package Managers](./README.md#platforms)
+- [Contributing](./README.md#contributing)
+- [Architecture Diagram](./README.md#architecture)
+- [Code of Conduct](./CODE_OF_CONDUCT.md)
+- [Contribution Guidelines](./CONTRIBUTING.md)
+- [Contributors](./README.md#contributor)
+- [Quick Links](./README.md#quicklinks)
+- [Credits](./README.md#credits)
+- [Hacking](./HACKING.md)
+- [License](./README.md#licence)
 
 ## <a name="features"></a>Features
 
@@ -57,46 +57,46 @@ server that handles different calls (specified by the LSP spec).
 This project provides in-file assistance to writing, editing and navigating
 CircleCI Configuration files. It offers:
 
--   **Rich code navigation through “go-to-definition” and “go-to-reference”
-    commands**. This is especially convenient when working on large
-    configuration files, to verify the definition of custom jobs, executors
-    parameters, or in turn view where any of them are referenced in the file.
-    Assisted code navigation also works for Orbs, allowing to explore their
-    definition directly in the IDE when using the go-to-definition feature on an
-    orb-defined command or parameter.
+- **Rich code navigation through “go-to-definition” and “go-to-reference”
+  commands**. This is especially convenient when working on large configuration
+  files, to verify the definition of custom jobs, executors parameters, or in
+  turn view where any of them are referenced in the file. Assisted code
+  navigation also works for Orbs, allowing to explore their definition directly
+  in the IDE when using the go-to-definition feature on an orb-defined command
+  or parameter.
 
 <p align="center">
     <img src="https://images.ctfassets.net/il1yandlcjgk/3JVSu8rTDQRJcIMGF866oJ/444091930e6c64dc9d52f17755e16af9/config_helper_go-to-definition-optimised.gif" alt="circleci-vscode-go-to-definition" width="50%"/>
 </p>
 
--   **Contextual documentation and usage hints when hovering on specific keys**,
-    so to avoid you having to continuously switch to your browser to check the
-    docs whenever you are editing your configuration. That said, links to the
-    official CircleCI documentation are also provided on hover - for easier
-    navigation.
+- **Contextual documentation and usage hints when hovering on specific keys**,
+  so to avoid you having to continuously switch to your browser to check the
+  docs whenever you are editing your configuration. That said, links to the
+  official CircleCI documentation are also provided on hover - for easier
+  navigation.
 
 <p align="center">
     <img src="https://images.ctfassets.net/il1yandlcjgk/6bloAnI35jXou9Q91aGFgU/356b1554d42c77fb2708fac980a8d592/config_helper_on-hover-documentation.png" alt="circleci-vscode-documentation-on-hover" width="50%"/>
 </p>
 
--   **Syntax validation** - which makes it much easier to identify typos,
-    incorrect use of parameters, incomplete definitions, wrong types, invalid or
-    deprecated machine versions, etc.
+- **Syntax validation** - which makes it much easier to identify typos,
+  incorrect use of parameters, incomplete definitions, wrong types, invalid or
+  deprecated machine versions, etc.
 
 <p align="center">
     <img src="https://images.ctfassets.net/il1yandlcjgk/1dF1ic2cUczaMYdxnSUZuF/fbc1eb5d5894a803caf297c57e808738/config_helper_syntax-validation.gif" alt="circleci-vscode-syntax-validation" width="50%"/>
 </p>
 
--   **Usage warnings** - which can help identify deprecated parameters, unused
-    jobs or executors, or missing keys that prevent you from taking advantage of
-    CircleCI’s full capabilities
+- **Usage warnings** - which can help identify deprecated parameters, unused
+  jobs or executors, or missing keys that prevent you from taking advantage of
+  CircleCI’s full capabilities
 
 <p align="center">
     <img src="https://images.ctfassets.net/il1yandlcjgk/404bGppmtCgvE0WOmPk0E/0a92e373929d6d19c8f5a742f1097511/config_helper_usage-warning.png" alt="circleci-vscode-usage-warnings" width="50%"/>
 </p>
 
--   **Auto completion**, available both on built-in keys and parameters and on
-    user-defined variables
+- **Auto completion**, available both on built-in keys and parameters and on
+  user-defined variables
 
 <p align="center">
     <img src="https://images.ctfassets.net/il1yandlcjgk/3jXaQvhOQgayhV9O4nfAhZ/b6d55e689ddfcf7673ab7e9b76ba0a53/config_helper_autocomplete.png" alt="circleci-vscode-autocomplete" width="50%"/>
@@ -127,13 +127,13 @@ YAML Language Server can be found in [HACKING.md](HACKING.md).
 
 ## <a name="quicklinks"></a>Quick links
 
--   [Install the VS Code extension using our language server](https://marketplace.visualstudio.com/items?itemName=circleci.circleci)
+- [Install the VS Code extension using our language server](https://marketplace.visualstudio.com/items?itemName=circleci.circleci)
 
--   [Discover how the language server was leveraged for the VS Code extension](https://youtu.be/Sdi7ctAXe2A)
+- [Discover how the language server was leveraged for the VS Code extension](https://youtu.be/Sdi7ctAXe2A)
 
--   [Learn more about CircleCI](https://circleci.com/)
+- [Learn more about CircleCI](https://circleci.com/)
 
--   [Do you have questions? Ask the circleCI community Discuss](https://discuss.circleci.com/)
+- [Do you have questions? Ask the circleCI community Discuss](https://discuss.circleci.com/)
 
 ## Social media links
 

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ server that handles different calls (specified by the LSP spec).
 - [Code of Conduct](./CODE_OF_CONDUCT.md)
 - [Contribution Guidelines](./CONTRIBUTING.md)
 - [Contributors](./README.md#contributor)
+- [Language clients](./README.md#language-server-clients)
 - [Quick Links](./README.md#quicklinks)
 - [Credits](./README.md#credits)
 - [Hacking](./HACKING.md)
@@ -125,6 +126,15 @@ YAML Language Server can be found in [HACKING.md](HACKING.md).
 
 ![alt text](./assets/diagram.jpg)
 
+## Language Server clients
+
+- VSCode:
+  [CircleCI VSCode extension](https://marketplace.visualstudio.com/items?itemName=circleci.circleci)
+- Neovim: [tomoakley Neovim plugin](https://github.com/tomoakley/circleci.nvim)
+
+If you which to implement a client for your editor, please take a look at
+[ADD_A_CLIENT.md](./ADD_A_CLIENT.md)
+
 ## <a name="quicklinks"></a>Quick links
 
 - [Install the VS Code extension using our language server](https://marketplace.visualstudio.com/items?itemName=circleci.circleci)
@@ -139,10 +149,10 @@ YAML Language Server can be found in [HACKING.md](HACKING.md).
 
 <a href="https://twitter.com/intent/tweet?text=Take%20a%20look%20at%20the%20open%20sourced%20CircleCI%20Language%20Server%20on%20GitHub%20https%3A//github.com/CircleCI-Public/circleci-yaml-language-server%23readme%20via%20%40CircleCI" style="align:center; margin-right:15px">
     <img src="./assets/social/tw.png" alt="twitter-link" width="60px"/>
-</a> 
+</a>
 <a href="https://www.facebook.com/sharer/sharer.php?u=https%3A//github.com/CircleCI-Public/circleci-yaml-language-server%23readme" style="align:center; margin-right:15px">
     <img src="./assets/social/fb.png" alt="facebook-link" width="60px"/>
-</a> 
+</a>
 <a href="https://www.linkedin.com/shareArticle?mini=true&url=https%3A//github.com/CircleCI-Public/circleci-yaml-language-server%23readme" style="align:center">
     <img src="./assets/social/ln.png" alt="linkedin-link" width="60px"/>
 </a>


### PR DESCRIPTION
[Jira](https://circleci.atlassian.net/browse/LIFE-150)

# Description

Adds a doc detailing the specifics about implementing a client for the Language Server.

# Implementation details

Prettier messed the README a bit so the PR is split in 2 commits: one to prettier the README and one to update the doc. You may want to look into the second commit only.

# How to validate

Read the doc.