### PR TITLE
fix: remove deprecated class

### DIFF
--- a/pkg/parser/validate/executor.go
+++ b/pkg/parser/validate/executor.go
@@ -41,13 +41,6 @@ func (val Validate) validateMacOSExecutor(executor ast.MacOSExecutor) {
 			executor.ResourceClassRange,
 			fmt.Sprintf("Xcode version \"%s\"", executor.Xcode),
 		)
-	} else if slices.Contains(utils.ValidXcodeIntelVersions, executor.Xcode) {
-		val.checkIfValidResourceClass(
-			executor.ResourceClass,
-			utils.ValidMacOSIntelResourceClasses,
-			executor.ResourceClassRange,
-			fmt.Sprintf("Xcode version \"%s\"", executor.Xcode),
-		)
 	} else {
 		val.addDiagnostic(utils.CreateErrorDiagnosticFromRange(
 			executor.XcodeRange,

--- a/pkg/parser/validate/executor.go
+++ b/pkg/parser/validate/executor.go
@@ -34,10 +34,10 @@ func (val Validate) ValidateExecutors() {
 // MacOSExecutor
 
 func (val Validate) validateMacOSExecutor(executor ast.MacOSExecutor) {
-	if slices.Contains(utils.ValidXcodeAppleSiliconVersions, executor.Xcode) {
+	if slices.Contains(utils.ValidXcodeVersions, executor.Xcode) {
 		val.checkIfValidResourceClass(
 			executor.ResourceClass,
-			utils.ValidMacOSAppleSiliconResourceClasses,
+			utils.ValidMacOSResourceClasses,
 			executor.ResourceClassRange,
 			fmt.Sprintf("Xcode version \"%s\"", executor.Xcode),
 		)

--- a/pkg/parser/validate/jobs_test.go
+++ b/pkg/parser/validate/jobs_test.go
@@ -135,7 +135,7 @@ func TestResourceClass(t *testing.T) {
 			yamlData: `jobs:
   test:
     macos:
-      xcode: ` + utils.ValidXcodeAppleSiliconVersions[0] + `
+      xcode: ` + utils.ValidXcodeVersions[0] + `
     resource_class: toto
     steps:
       - checkout`,

--- a/pkg/utils/executors.go
+++ b/pkg/utils/executors.go
@@ -184,19 +184,6 @@ var ValidMachinePairs = []struct {
 	{Images: ValidWindowsGPUImages, ResourceClasses: ValidWindowsGPUResourceClasses},
 }
 
-var ValidXcodeIntelVersions = []string{
-	"15.3.0",
-	"15.2.0",
-	"15.1.0",
-	"15.0.0",
-	"14.3.1",
-	"14.2.0",
-	"14.1.0",
-	"14.0.1",
-	"13.4.1",
-	"12.5.1",
-}
-
 var ValidXcodeAppleSiliconVersions = []string{
 	"15.4.0",
 	"15.3.0",

--- a/pkg/utils/executors.go
+++ b/pkg/utils/executors.go
@@ -197,10 +197,6 @@ var ValidXcodeIntelVersions = []string{
 	"12.5.1",
 }
 
-var ValidMacOSIntelResourceClasses = []string{
-	"macos.x86.medium.gen2",
-}
-
 var ValidXcodeAppleSiliconVersions = []string{
 	"15.4.0",
 	"15.3.0",
@@ -219,10 +215,7 @@ var ValidMacOSAppleSiliconResourceClasses = []string{
 	"macos.m1.large.gen1",
 }
 
-var ValidMacOSResourceClasses = slices.Concat(
-	ValidMacOSAppleSiliconResourceClasses,
-	ValidMacOSIntelResourceClasses,
-)
+var ValidMacOSResourceClasses = ValidMacOSAppleSiliconResourceClasses
 
 var ValidDockerResourceClasses = ValidLinuxResourceClasses
 

--- a/pkg/utils/executors.go
+++ b/pkg/utils/executors.go
@@ -185,6 +185,7 @@ var ValidMachinePairs = []struct {
 }
 
 var ValidXcodeVersions = []string{
+	"16.0.0",
 	"15.4.0",
 	"15.3.0",
 	"15.2.0",

--- a/pkg/utils/executors.go
+++ b/pkg/utils/executors.go
@@ -184,7 +184,7 @@ var ValidMachinePairs = []struct {
 	{Images: ValidWindowsGPUImages, ResourceClasses: ValidWindowsGPUResourceClasses},
 }
 
-var ValidXcodeAppleSiliconVersions = []string{
+var ValidXcodeVersions = []string{
 	"15.4.0",
 	"15.3.0",
 	"15.2.0",
@@ -197,12 +197,10 @@ var ValidXcodeAppleSiliconVersions = []string{
 	"13.4.1",
 }
 
-var ValidMacOSAppleSiliconResourceClasses = []string{
+var ValidMacOSResourceClasses = []string{
 	"macos.m1.medium.gen1",
 	"macos.m1.large.gen1",
 }
-
-var ValidMacOSResourceClasses = ValidMacOSAppleSiliconResourceClasses
 
 var ValidDockerResourceClasses = ValidLinuxResourceClasses
 

--- a/publicschema.json
+++ b/publicschema.json
@@ -517,7 +517,6 @@
                             "gpu.nvidia.small",
                             "gpu.nvidia.medium",
                             "windows.gpu.nvidia.medium",
-                            "macos.x86.medium.gen2",
                             "macos.m1.medium.gen1",
                             "macos.m1.large.gen1"
                         ]


### PR DESCRIPTION
[Jira](https://circleci.atlassian.net/browse/XXXX-1234)

# Description

The macos.x86.medium.gen2 resource class is being deprecated on June 28, 2024.

# Implementation details

remove the resource class from public schema (auto complete) and config validation

# How to validate

test a config file with macos.x86.medium.gen2 as resource class

