### PR TITLE
feat(executors): add ubuntu 2024 image and update other ubuntu images to august release.

### DIFF
--- a/pkg/utils/executors.go
+++ b/pkg/utils/executors.go
@@ -5,10 +5,11 @@ import (
 	"strings"
 )
 
-var CurrentLinuxImage = "ubuntu-2204:current"
+var CurrentLinuxImage = "ubuntu-2404:current"
 
 var ValidLinuxImages = []string{
 	// Ubuntu 20.04
+	"ubuntu-2004:2024.08.1",
 	"ubuntu-2004:2024.05.1",
 	"ubuntu-2004:2024.04.4",
 	"ubuntu-2004:2024.01.2",
@@ -34,6 +35,7 @@ var ValidLinuxImages = []string{
 	"ubuntu-2004:edge",
 
 	// Ubuntu 22.04
+	"ubuntu-2204:2024.08.1",
 	"ubuntu-2204:2024.05.1",
 	"ubuntu-2204:2024.04.4",
 	"ubuntu-2204:2024.01.2",
@@ -51,6 +53,12 @@ var ValidLinuxImages = []string{
 	"ubuntu-2204:2022.04.1",
 	"ubuntu-2204:current",
 	"ubuntu-2204:edge",
+
+	// Ubuntu 24.04
+	"ubuntu-2404:2024.08.1",
+	"ubuntu-2404:2024.05.1",
+	"ubuntu-2404:current",
+	"ubuntu-2404:edge",
 
 	// Android
 	"android:2024.04.1",


### PR DESCRIPTION
See https://discuss.circleci.com/t/ubuntu-20-04-22-04-24-04-q3-edge-release/51699

[Jira](https://circleci.atlassian.net/browse/XXXX-1234)

# Description

Add ubuntu 2024 images to be recognized by the language server as well as the most recent august releases.

The VS Code plugin is currently not working for me as the parser breaks for the missing image value. I fixed the jsonschema upstream so VS Code will recognize it, but i think it needs to be fixed here as well.

# Implementation details

Just added the values

# How to validate

Use a circleci config and add one of the values i added.

