### PR TITLE
fix: handle Docker image tags with SHA256 hash

### DIFF
--- a/pkg/parser/dockerImageParser.go
+++ b/pkg/parser/dockerImageParser.go
@@ -2,6 +2,7 @@ package parser
 
 import (
 	"regexp"
+	"strings"
 
 	"github.com/CircleCI-Public/circleci-yaml-language-server/pkg/ast"
 )
@@ -36,6 +37,10 @@ func ParseDockerImageValue(value string) ast.DockerImageInfo {
 	if tag != "" {
 		// The regex includes the leading ":", just snip it
 		tag = tag[1:]
+		// Split at "@" and take only the version part before it
+		if strings.Contains(tag, "@") {
+			tag = strings.Split(tag, "@")[0]
+		}
 	}
 
 	return ast.DockerImageInfo{

--- a/pkg/parser/dockerImageParser_test.go
+++ b/pkg/parser/dockerImageParser_test.go
@@ -120,6 +120,19 @@ func Test_parseDockerImageValue(t *testing.T) {
 				FullPath:  "cimg/go:<<parameters.go_version>>",
 			},
 		},
+
+		{
+			name: "",
+			args: args{
+				value: "cimg/node:22.11.0@sha256:76aae59c6259672ab68819b8960de5ef571394681089eab2b576f85f080c73ba",
+			},
+			want: ast.DockerImageInfo{
+				Namespace: "cimg",
+				Tag:       "22.11.0",
+				Name:      "node",
+				FullPath:  "cimg/node:22.11.0@sha256:76aae59c6259672ab68819b8960de5ef571394681089eab2b576f85f080c73ba",
+			},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
# Description
Fixes an issue where Docker images with SHA256 hashes in their tags were being incorrectly validated, resulting in false "Missing image tag" errors. The fix modifies the tag parsing logic to properly handle tags that include SHA256 hashes by extracting only the version number portion for validation purposes.

For example, with an image like `cimg/node:22.11.0@sha256:76aae59c6259672ab68819b8960de5ef571394681089eab2b576f85f080c73ba`, the system now correctly extracts `22.11.0` as the tag for validation while preserving the full reference.

```yaml
version: 2.1

jobs:
  build:
    docker:
      - image: cimg/node:22.11.0@sha256:76aae59c6259672ab68819b8960de5ef571394681089eab2b576f85f080c73ba
    steps:
      - checkout
      - run:
          name: Install Dependencies
          command: npm install
workflows:
  build:
    jobs:
      - build
```

![image](https://github.com/user-attachments/assets/6ae78dd3-6bef-4a2b-abb1-2b8e5df72e38)


# Implementation details
- Modified `parseDockerImageValue` in `dockerImageParser.go` to split tags at "@" and use only the version part for validation
- Added test case in `dockerImageParser_test.go` to verify correct handling of tags with SHA256 hashes
- Preserves the full image reference including SHA256 hash in `FullPath` field