### PR TITLE
feat: extend the schema of the requires stanza

### DIFF
--- a/pkg/ast/workflow.go
+++ b/pkg/ast/workflow.go
@@ -27,7 +27,7 @@ type JobRef struct {
 	// not the job that will be executed
 	StepName      string
 	StepNameRange protocol.Range
-	Requires      []TextAndRange
+	Requires      []Require
 	Context       []TextAndRange
 	Type          string
 	TypeRange     protocol.Range
@@ -44,8 +44,9 @@ type JobRef struct {
 }
 
 type Require struct {
-	Name  string
-	Range protocol.Range
+	Name   string
+	Status []string
+	Range  protocol.Range
 }
 
 type WorkflowTrigger struct {

--- a/pkg/parser/validate/workflow.go
+++ b/pkg/parser/validate/workflow.go
@@ -42,10 +42,10 @@ func (val Validate) validateSingleWorkflow(workflow ast.Workflow) error {
 			val.validateWorkflowParameters(jobRef, jobRef.JobName, jobRef.JobRefRange)
 		}
 		for _, require := range jobRef.Requires {
-			if !val.doesJobRefExist(workflow, require.Text) && !utils.CheckIfMatrixParamIsPartiallyReferenced(require.Text) {
+			if !val.doesJobRefExist(workflow, require.Name) && !utils.CheckIfMatrixParamIsPartiallyReferenced(require.Name) {
 				val.addDiagnostic(utils.CreateErrorDiagnosticFromRange(
 					require.Range,
-					fmt.Sprintf("Cannot find declaration for job reference %s", require.Text)))
+					fmt.Sprintf("Cannot find declaration for job reference %s", require.Name)))
 			}
 		}
 

--- a/pkg/parser/workflows_test.go
+++ b/pkg/parser/workflows_test.go
@@ -35,6 +35,14 @@ func TestYamlDocument_parseSingleJobReference(t *testing.T) {
 	const jobRef4 = `
 - test:
     name: say-my-name`
+	const jobRef5 = `
+- test:
+    requires:
+        - setup: failed`
+	const jobRef6 = `
+- test:
+    requires:
+        - setup: [success, canceled]`
 
 	type fields struct {
 		Content   []byte
@@ -128,9 +136,10 @@ func TestYamlDocument_parseSingleJobReference(t *testing.T) {
 						Character: 6,
 					},
 				},
-				Requires: []ast.TextAndRange{
+				Requires: []ast.Require{
 					{
-						Text: "setup",
+						Name:   "setup",
+						Status: []string{"success"},
 						Range: protocol.Range{
 							Start: protocol.Position{Line: 3, Character: 10},
 							End:   protocol.Position{Line: 3, Character: 15},
@@ -302,6 +311,108 @@ func TestYamlDocument_parseSingleJobReference(t *testing.T) {
 				Parameters:   make(map[string]ast.ParameterValue),
 				HasMatrix:    false,
 				MatrixParams: make(map[string][]ast.ParameterValue),
+			},
+		},
+		{
+			name:   "Job reference with requires and single status",
+			fields: fields{Content: []byte(jobRef5)},
+			args:   args{jobRefNode: getFirstChildOfType(GetRootNode([]byte(jobRef5)), "block_sequence_item")},
+			want: ast.JobRef{
+				JobName: "test",
+				JobRefRange: protocol.Range{
+					Start: protocol.Position{
+						Line:      1,
+						Character: 0,
+					},
+					End: protocol.Position{
+						Line:      3,
+						Character: 23,
+					},
+				},
+				JobNameRange: protocol.Range{
+					Start: protocol.Position{
+						Line:      1,
+						Character: 2,
+					},
+					End: protocol.Position{
+						Line:      1,
+						Character: 6,
+					},
+				},
+				StepName: "test",
+				StepNameRange: protocol.Range{
+					Start: protocol.Position{
+						Line:      1,
+						Character: 2,
+					},
+					End: protocol.Position{
+						Line:      1,
+						Character: 6,
+					},
+				},
+				Requires: []ast.Require{
+					{
+						Name:   "setup",
+						Status: []string{"failed"},
+						Range: protocol.Range{
+							Start: protocol.Position{Line: 3, Character: 10},
+							End:   protocol.Position{Line: 3, Character: 15},
+						},
+					},
+				},
+				MatrixParams: make(map[string][]ast.ParameterValue),
+				Parameters:   make(map[string]ast.ParameterValue),
+			},
+		},
+		{
+			name:   "Job reference with requires and multiple statuses",
+			fields: fields{Content: []byte(jobRef6)},
+			args:   args{jobRefNode: getFirstChildOfType(GetRootNode([]byte(jobRef6)), "block_sequence_item")},
+			want: ast.JobRef{
+				JobName: "test",
+				JobRefRange: protocol.Range{
+					Start: protocol.Position{
+						Line:      1,
+						Character: 0,
+					},
+					End: protocol.Position{
+						Line:      3,
+						Character: 36,
+					},
+				},
+				JobNameRange: protocol.Range{
+					Start: protocol.Position{
+						Line:      1,
+						Character: 2,
+					},
+					End: protocol.Position{
+						Line:      1,
+						Character: 6,
+					},
+				},
+				StepName: "test",
+				StepNameRange: protocol.Range{
+					Start: protocol.Position{
+						Line:      1,
+						Character: 2,
+					},
+					End: protocol.Position{
+						Line:      1,
+						Character: 6,
+					},
+				},
+				Requires: []ast.Require{
+					{
+						Name:   "setup",
+						Status: []string{"success", "canceled"},
+						Range: protocol.Range{
+							Start: protocol.Position{Line: 3, Character: 10},
+							End:   protocol.Position{Line: 3, Character: 15},
+						},
+					},
+				},
+				MatrixParams: make(map[string][]ast.ParameterValue),
+				Parameters:   make(map[string]ast.ParameterValue),
 			},
 		},
 	}

--- a/pkg/services/definition/workflows.go
+++ b/pkg/services/definition/workflows.go
@@ -29,11 +29,11 @@ func (def DefinitionStruct) searchForWorkflows() []protocol.Location {
 	return []protocol.Location{}
 }
 
-func (def DefinitionStruct) searchForWorkflowJobsRequires(requires []ast.TextAndRange, workflow ast.Workflow) []protocol.Location {
+func (def DefinitionStruct) searchForWorkflowJobsRequires(requires []ast.Require, workflow ast.Workflow) []protocol.Location {
 	for _, require := range requires {
 		if utils.PosInRange(require.Range, def.Params.Position) {
 			for _, jobRef := range workflow.JobRefs {
-				if jobRef.JobName == require.Text {
+				if jobRef.JobName == require.Name {
 					return []protocol.Location{
 						{
 							URI:   def.Params.TextDocument.URI,

--- a/pkg/services/diagnostics_test.go
+++ b/pkg/services/diagnostics_test.go
@@ -36,6 +36,11 @@ func TestFindErrors(t *testing.T) {
 			args: args{filePath: "./testdata/anchorNoErrors.yml"},
 			want: make([]protocol.Diagnostic, 0),
 		},
+		{
+			name: "No errors",
+			args: args{filePath: "./testdata/requiresNoErrors.yml"},
+			want: make([]protocol.Diagnostic, 0),
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/services/testdata/requiresNoErrors.yml
+++ b/pkg/services/testdata/requiresNoErrors.yml
@@ -1,0 +1,41 @@
+version: 2.1
+
+jobs:
+  build:
+    docker:
+      - image: node:latest
+    steps:
+      - checkout
+      - run: echo "build"
+  somejob:
+    docker:
+      - image: node:latest
+    steps:
+      - checkout
+      - run: echo "somejob"
+  someotherjob:
+    docker:
+      - image: node:latest
+    steps:
+      - checkout
+      - run: echo "somejob"
+  anotherjob:
+    docker:
+      - image: node:latest
+    steps:
+      - checkout
+      - run: echo "anotherjob"
+
+workflows:
+  test-build:
+    jobs:
+      - build
+      - somejob
+      - someotherjob
+      - anotherjob:
+          requires:
+              - build: failed
+              - somejob:
+                  - success
+                  - canceled
+              - someotherjob: [canceled, failed]

--- a/schema.json
+++ b/schema.json
@@ -1525,7 +1525,33 @@
 											"requires": {
 												"type": "array",
 												"items": {
-													"type": "string"
+													"oneOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "object",
+                              "minProperties": 1,
+                              "maxProperties": 1,
+                              "patternProperties": {
+                                "^[A-Za-z][A-Za-z\\s\\d_-]*$": {
+                                  "oneOf": [
+                                    {
+                                      "type": "string",
+                                      "enum": ["success", "failed", "canceled"]
+                                    },
+                                    {
+                                      "type": "array",
+                                      "minLength": 1,
+                                      "items": {
+                                        "type": "string",
+                                        "enum": ["success", "failed", "canceled"]
+                                      }
+                                    }
+                                  ]
+                                }}
+                            }
+                          ]
 												}
 											},
 											"filters": {


### PR DESCRIPTION
[Jira](https://circleci.atlassian.net/browse/PIPE-4895)

# Description

This changes the schema of the `requires` stanza in order to support the flexible requires feature. This will provide customers the ability to define a job's dependencies along with the statuses the dependency must have , in order for the job to start.

This is an example config that demonstrates the new syntax:
```yaml
jobs:
  - a
  - b
  - c:
    requires:
      - a
      - b:
        - success
        - failed
  - d:
    requires:
      - b: canceled
```


# Implementation details

- Update the schema.json to extend the schema of the `requires` stanza
- Update the `parseSingleJobRequires` to handle the new schema
- Update tests

# How to validate

Unit tests

