### PR TITLE
Updated Snyk scanning

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -498,7 +498,7 @@ jobs:
       - snyk/scan:
           fail-on-issues: false
           severity-threshold: high
-          monitor-on-build: true
+          monitor-on-build: false
           project: "${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}"
 
   Security Scan feature:


### PR DESCRIPTION
# Description

We are moving to another tool and therefore we do not need to upload results to Snyk anymore.

# Implementation details

We can continue to scan, just not upload results.

# How to validate

If the CI jobs still runs and completes, then it's good.

