### PR TITLE
chore: remove feature PR workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -501,37 +501,6 @@ jobs:
           monitor-on-build: false
           project: "${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}"
 
-  Security Scan feature:
-    docker:
-      - image: cimg/go:1.22.3
-    steps:
-      - checkout
-      - run:
-          name: Setup Scanning
-          command: |
-            git config --global url."https://$GITHUB_USER:$GITHUB_TOKEN@github.com/circleci/".insteadOf "https://github.com/circleci/"
-      - snyk/scan:
-          fail-on-issues: false
-          severity-threshold: high
-          monitor-on-build: false
-          project: "${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/${CIRCLE_BRANCH}"
-
-  Auto-assign PR:
-    docker:
-      - image: cimg/node:18.16
-    steps:
-      - run:
-          name: Halt job if running pipeline from a fork
-          command: |
-            [ -z $CIRCLE_PR_NUMBER ] || circleci-agent step halt
-      - github-cli/install:
-          version: "2.37.0"
-      - checkout
-      - run:
-          name: Assign PR to author
-          command: |
-            gh pr edit --add-assignee $(gh pr view --json author --jq .author.login)
-
 workflows:
   Release PR:
     when: &release-conditions
@@ -672,10 +641,6 @@ workflows:
       not: *release-conditions
     jobs:
       - Unit Tests
-      - Security Scan feature:
-          context:
-            - devex-release
-            - org-global-employees
       - Lint
       - Create version file:
           is-prerelease: true

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -667,17 +667,6 @@ workflows:
           context:
             - devex-release
 
-  Feature PR:
-    when:
-      not: *release-conditions
-    jobs:
-      - Lint PR title:
-          context:
-            - devex-release
-      - Auto-assign PR:
-          context:
-            - devex-release
-
   Build and test:
     when:
       not: *release-conditions

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,21 @@
+name: "Lint PR"
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+      - reopened
+
+permissions:
+  pull-requests: read
+
+jobs:
+  main:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
[Jira](https://circleci.atlassian.net/browse/LIFE-1129)

# Description

- Removes the Feature PR workflow and the Security Scan job (on release branches)

These workflows/jobs require the use of the devex-release context, which is only available to CCI employees. In order to enable external contributions, I've refactored the config so that the context isn't required until build time.

EDIT: I have replaced the `Lint PR title` with a github action as recommended below. This won't run against this PR, only on subsequent ones. 

# How to validate

Not entirely sure about this yet. I think after this is merged, I'm going to have to create a separate github account to test a commit and see if it makes it to CI.

