### PR TITLE
chore(server): Add new Windows 2022 Nvidia image

### DIFF
--- a/pkg/utils/executors.go
+++ b/pkg/utils/executors.go
@@ -170,6 +170,8 @@ var ValidLinuxGPUResourceClasses = []string{
 var ValidWindowsGPUImages = []string{
 	"windows-server-2019-cuda:current",
 	"windows-server-2019-cuda:edge",
+	"windows-server-2022-cuda:current",
+	"windows-server-2022-cuda:edge",
 }
 
 var ValidWindowsGPUResourceClasses = []string{


### PR DESCRIPTION
# Description

This PR adds a new windows 2022 server image for CUDA

- https://circleci.com/developer/machine/image/windows-server-2022-cuda

# Implementation details

Added new image to existing array of images

# How to validate

Here’s a quick usage example:
```
version: 2.1

jobs:
  build:
    machine:
      image: 'windows-server-2019-cuda:edge'
      resource_class: windows.gpu.nvidia.medium
      shell: powershell.exe -ExecutionPolicy Bypass
    steps:
      - run: Write-Host 'Hello, Windows'
```

