### PR TITLE
feat: PIPE-5084 Update job references to support serial groups

### DIFF
--- a/pkg/ast/workflow.go
+++ b/pkg/ast/workflow.go
@@ -25,13 +25,15 @@ type JobRef struct {
 
 	// StepName is the name of the job in the workflow,
 	// not the job that will be executed
-	StepName      string
-	StepNameRange protocol.Range
-	Requires      []Require
-	Context       []TextAndRange
-	Type          string
-	TypeRange     protocol.Range
-	Parameters    map[string]ParameterValue
+	StepName         string
+	StepNameRange    protocol.Range
+	Requires         []Require
+	Context          []TextAndRange
+	Type             string
+	TypeRange        protocol.Range
+	Parameters       map[string]ParameterValue
+	SerialGroup      string
+	SerialGroupRange protocol.Range
 
 	PreSteps      []Step
 	PreStepsRange protocol.Range

--- a/pkg/parser/validate/workflow_test.go
+++ b/pkg/parser/validate/workflow_test.go
@@ -64,6 +64,19 @@ workflows:
 `,
 			Diagnostics: []protocol.Diagnostic{},
 		},
+		{
+			Name: "Serial groups",
+			YamlContent: `version: 2.1
+jobs:
+	- deploy:
+			type: no-op
+
+workflows:
+ someworkflow:
+	 jobs:
+		 - deploy:
+					serial-group: deploy-group`,
+		},
 	}
 
 	CheckYamlErrors(t, testCases)

--- a/pkg/parser/workflows.go
+++ b/pkg/parser/workflows.go
@@ -212,6 +212,9 @@ func (doc *YamlDocument) parseSingleJobReference(jobRefNode *sitter.Node) ast.Jo
 					if alias != "" {
 						res.StepName = alias
 					}
+				case "serial-group":
+					res.SerialGroup = doc.GetNodeText(valueNode)
+					res.SerialGroupRange = doc.NodeToRange(valueNode)
 
 				case "pre-steps":
 					res.PreStepsRange = doc.NodeToRange(child)

--- a/pkg/parser/workflows_test.go
+++ b/pkg/parser/workflows_test.go
@@ -43,6 +43,9 @@ func TestYamlDocument_parseSingleJobReference(t *testing.T) {
 - test:
     requires:
         - setup: [success, canceled]`
+	const jobRef7 = `
+- deploy:
+    serial-group: deploy-group`
 
 	type fields struct {
 		Content   []byte
@@ -413,6 +416,59 @@ func TestYamlDocument_parseSingleJobReference(t *testing.T) {
 				},
 				MatrixParams: make(map[string][]ast.ParameterValue),
 				Parameters:   make(map[string]ast.ParameterValue),
+			},
+		},
+		{
+			name:   "Job reference with serial group",
+			fields: fields{Content: []byte(jobRef7)},
+			args:   args{jobRefNode: getFirstChildOfType(GetRootNode([]byte(jobRef7)), "block_sequence_item")},
+			want: ast.JobRef{
+				JobName: "deploy",
+				JobRefRange: protocol.Range{
+					Start: protocol.Position{
+						Line:      1,
+						Character: 0,
+					},
+					End: protocol.Position{
+						Line:      2,
+						Character: 30,
+					},
+				},
+				JobNameRange: protocol.Range{
+					Start: protocol.Position{
+						Line:      1,
+						Character: 2,
+					},
+					End: protocol.Position{
+						Line:      1,
+						Character: 8,
+					},
+				},
+				StepName: "deploy",
+				StepNameRange: protocol.Range{
+					Start: protocol.Position{
+						Line:      1,
+						Character: 2,
+					},
+					End: protocol.Position{
+						Line:      1,
+						Character: 8,
+					},
+				},
+				Parameters:   make(map[string]ast.ParameterValue),
+				HasMatrix:    false,
+				MatrixParams: make(map[string][]ast.ParameterValue),
+				SerialGroup:  "deploy-group",
+				SerialGroupRange: protocol.Range{
+					Start: protocol.Position{
+						Line:      2,
+						Character: 18,
+					},
+					End: protocol.Position{
+						Line:      2,
+						Character: 30,
+					},
+				},
 			},
 		},
 	}

--- a/pkg/services/testdata/noErrors.yml
+++ b/pkg/services/testdata/noErrors.yml
@@ -88,6 +88,9 @@ jobs:
     steps:
       - run: echo "Hello"
 
+  deploy:
+    <<: *buildJob
+
 workflows:
   test-build:
     jobs:
@@ -125,3 +128,6 @@ workflows:
       - jobWithAWS_OIDC
       - ccc/random-job
       - jobWithUnaccessibleOrb
+
+      - deploy:
+          serial-group: << pipeline.project.slug >>/deploy-group

--- a/schema.json
+++ b/schema.json
@@ -1676,6 +1676,10 @@
 														"type": "string"
 													}
 												}
+											},
+											"serial-group": {
+												"type": "string",
+												"minLength": 1
 											}
 										}
 									}


### PR DESCRIPTION
[Jira](https://circleci.atlassian.net/browse/PIPE-5084)

# Description

Serial groups are groups of jobs that run in series, this is a new property that can be set for any job type.

For example, creating multiple pipelines at the same time with the below config will result in all pipelines running `test` and `build` but only a single pipeline will run `deploy` at a time.

```yaml
version: 2.1

jobs:
  test:
    type: no-op

  build:
    type: no-op

  deploy:
    type: no-op

workflows:
  main-workflow:
    jobs:
      - test
      - build
      - deploy:
          serial-group: << pipeline.project.slug >>/deploy-group
          requires:
            - test
            - build
```

# Implementation details

Serial group keys when compiled:
- Are optional and defined on the job invocation.
- Must be a non-empty string fewer than 512 characters.

Note: this is after compilation, limiting what we can validate here, this would be valid.

```yaml
parameters:
  key-longer-than-512-chars:
    type: string
    default: "foo"

  ...
  serial-group: << pipeline.parameters.key-longer-than-512-chars >>
```

# How to validate

- Unit tests pass.
- Paste the above config in any test project.
- Push a change and confirm it works.

