### PR TITLE
feat: Update job references to support overrides

### DIFF
--- a/pkg/ast/workflow.go
+++ b/pkg/ast/workflow.go
@@ -25,15 +25,17 @@ type JobRef struct {
 
 	// StepName is the name of the job in the workflow,
 	// not the job that will be executed
-	StepName         string
-	StepNameRange    protocol.Range
-	Requires         []Require
-	Context          []TextAndRange
-	Type             string
-	TypeRange        protocol.Range
-	Parameters       map[string]ParameterValue
-	SerialGroup      string
-	SerialGroupRange protocol.Range
+	StepName          string
+	StepNameRange     protocol.Range
+	Requires          []Require
+	Context           []TextAndRange
+	Type              string
+	TypeRange         protocol.Range
+	Parameters        map[string]ParameterValue
+	SerialGroup       string
+	SerialGroupRange  protocol.Range
+	OverrideWith      string
+	OverrideWithRange protocol.Range
 
 	PreSteps      []Step
 	PreStepsRange protocol.Range

--- a/pkg/parser/validate/workflow_test.go
+++ b/pkg/parser/validate/workflow_test.go
@@ -77,6 +77,19 @@ workflows:
 		 - deploy:
 					serial-group: deploy-group`,
 		},
+		{
+			Name: "Job override",
+			YamlContent: `version: 2.1
+jobs:
+	- deploy:
+			type: no-op
+
+workflows:
+ someworkflow:
+	 jobs:
+		 - deploy:
+					override-with: local/deploy`,
+		},
 	}
 
 	CheckYamlErrors(t, testCases)

--- a/pkg/parser/workflows.go
+++ b/pkg/parser/workflows.go
@@ -215,6 +215,9 @@ func (doc *YamlDocument) parseSingleJobReference(jobRefNode *sitter.Node) ast.Jo
 				case "serial-group":
 					res.SerialGroup = doc.GetNodeText(valueNode)
 					res.SerialGroupRange = doc.NodeToRange(valueNode)
+				case "override-with":
+					res.OverrideWith = doc.GetNodeText(valueNode)
+					res.OverrideWithRange = doc.NodeToRange(valueNode)
 
 				case "pre-steps":
 					res.PreStepsRange = doc.NodeToRange(child)

--- a/pkg/parser/workflows_test.go
+++ b/pkg/parser/workflows_test.go
@@ -46,6 +46,9 @@ func TestYamlDocument_parseSingleJobReference(t *testing.T) {
 	const jobRef7 = `
 - deploy:
     serial-group: deploy-group`
+	const jobRef8 = `
+- deploy:
+    override-with: foo/deploy`
 
 	type fields struct {
 		Content   []byte
@@ -467,6 +470,59 @@ func TestYamlDocument_parseSingleJobReference(t *testing.T) {
 					End: protocol.Position{
 						Line:      2,
 						Character: 30,
+					},
+				},
+			},
+		},
+		{
+			name:   "Job reference with override",
+			fields: fields{Content: []byte(jobRef8)},
+			args:   args{jobRefNode: getFirstChildOfType(GetRootNode([]byte(jobRef8)), "block_sequence_item")},
+			want: ast.JobRef{
+				JobName: "deploy",
+				JobRefRange: protocol.Range{
+					Start: protocol.Position{
+						Line:      1,
+						Character: 0,
+					},
+					End: protocol.Position{
+						Line:      2,
+						Character: 29,
+					},
+				},
+				JobNameRange: protocol.Range{
+					Start: protocol.Position{
+						Line:      1,
+						Character: 2,
+					},
+					End: protocol.Position{
+						Line:      1,
+						Character: 8,
+					},
+				},
+				StepName: "deploy",
+				StepNameRange: protocol.Range{
+					Start: protocol.Position{
+						Line:      1,
+						Character: 2,
+					},
+					End: protocol.Position{
+						Line:      1,
+						Character: 8,
+					},
+				},
+				Parameters:   make(map[string]ast.ParameterValue),
+				HasMatrix:    false,
+				MatrixParams: make(map[string][]ast.ParameterValue),
+				OverrideWith: "foo/deploy",
+				OverrideWithRange: protocol.Range{
+					Start: protocol.Position{
+						Line:      2,
+						Character: 19,
+					},
+					End: protocol.Position{
+						Line:      2,
+						Character: 29,
 					},
 				},
 			},

--- a/pkg/services/testdata/noErrors.yml
+++ b/pkg/services/testdata/noErrors.yml
@@ -91,6 +91,12 @@ jobs:
   deploy:
     <<: *buildJob
 
+  check:
+    docker:
+      - image: node:latest
+    steps:
+      - run: echo "shellcheck"
+
 workflows:
   test-build:
     jobs:
@@ -131,3 +137,6 @@ workflows:
 
       - deploy:
           serial-group: << pipeline.project.slug >>/deploy-group
+
+      - check:
+          override-with: shellcheck/check

--- a/schema.json
+++ b/schema.json
@@ -1680,7 +1680,10 @@
 											"serial-group": {
 												"type": "string",
 												"minLength": 1
-											}
+											},
+                      "override-with": {
+                        "type": "string"
+                      }
 										}
 									}
 								}


### PR DESCRIPTION
[Jira](https://circleci.atlassian.net/browse/PIPE-5109)

# Description

A job can now be invoked inside a workflow with a job configuration override. For example:
```yaml
version: 2.1
orbs:
  foo: my-org/my-orb@1.1.1
  
jobs:
  build:
    steps: 
      - run: task build
  test:
    steps:
      - run: task test

workflows:
  - build-test:
      jobs:
        - build:
        - test:
            override-with: foo/my-test
            requires: build
```
The `test` job in the workflow is compiled with the job definition of `foo/my-test`.

# Implementation details
- Update the JSON schema to support the `override-with` key
- Update how job references are parsed to support `override-with`
- Update tests

# How to validate

Unit tests

