### PR TITLE
fix: correct a bad pattern in schema

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -968,7 +968,7 @@
 					"type": "object",
 					"description": "long form commands like `run:`",
 					"propertyNames": {
-						"pattern": "^[a-z][a-z\\d-\/_]*$",
+						"pattern": "^[a-z][a-z\\d\/_-]*$",
 						"not": {
 							"pattern": "^(when|unless)$"
 						}


### PR DESCRIPTION
# Description

Fixes #341

# Implementation details

I've only fixed one issue with this pattern, which is the placement of the hyphen such that regex engines may interpret it as part of a character range.

There is at least one other suspicious irregularity, which is the `\/` character sequence.
Perhaps `\\/` was meant. Or perhaps `\\\\/`. But the string does not appear to have been formulated with an eye to the layer of JSON escaping which is at play here.

Absent any clarity on what the intention of this regex is, I've limited this fix to the hyphen issue only.

# How to validate

Parse the expression using a variety of target regex engines -- JS is the presumptive target for this repo (?) -- and make sure it matches strings correctly.
