### PR TITLE
feat: add validation for values of step rerun fields

### DIFF
--- a/pkg/parser/validate/steps.go
+++ b/pkg/parser/validate/steps.go
@@ -2,8 +2,11 @@ package validate
 
 import (
 	"fmt"
+	"regexp"
 	"slices"
+	"strconv"
 	"strings"
+	"time"
 
 	"github.com/CircleCI-Public/circleci-yaml-language-server/pkg/ast"
 	"github.com/CircleCI-Public/circleci-yaml-language-server/pkg/utils"
@@ -15,6 +18,9 @@ var WHEN_KEYWORDS = []string{
 	"always",
 	"on_fail",
 }
+
+// AutoRerunDelay validation regex: matches 1-10 minutes or any number of seconds (but not both)
+var AUTO_RERUN_DELAY_REGEX = regexp.MustCompile(`^((10|[1-9])m|([1-9][0-9]*)s)$`)
 
 func (val Validate) validateSteps(steps []ast.Step, name string, jobOrCommandParameters map[string]ast.Parameter) error {
 	for _, step := range steps {
@@ -58,6 +64,48 @@ func (val Validate) validateRunCommand(step ast.Run, jobOrCommandParameters map[
 			Message:  "auto_rerun_delay requires max_auto_reruns to be specified",
 			Severity: protocol.DiagnosticSeverityError,
 		})
+	}
+
+	// Validate that max_auto_reruns is between 1 and 5
+	if step.MaxAutoReruns != "" {
+		rerunCount, err := strconv.Atoi(step.MaxAutoReruns)
+		if err != nil || rerunCount <= 0 || rerunCount > 5 {
+			val.addDiagnostic(protocol.Diagnostic{
+				Range:    step.Range,
+				Message:  "max_auto_reruns must be between 1 and 5",
+				Severity: protocol.DiagnosticSeverityError,
+			})
+		}
+	}
+
+	// Validate that auto_rerun_delay conforms to the specific format and duration limits
+	if step.AutoRerunDelay != "" {
+		// First check if it's a valid duration
+		duration, err := time.ParseDuration(step.AutoRerunDelay)
+		if err != nil {
+			val.addDiagnostic(protocol.Diagnostic{
+				Range:    step.Range,
+				Message:  "auto_rerun_delay must be a valid duration",
+				Severity: protocol.DiagnosticSeverityError,
+			})
+		} else {
+			// Check if it matches the required format
+			if !AUTO_RERUN_DELAY_REGEX.MatchString(step.AutoRerunDelay) {
+				val.addDiagnostic(protocol.Diagnostic{
+					Range:    step.Range,
+					Message:  "auto_rerun_delay must be in the format of 1-10 minutes (e.g., '1m', '10m') or any number of seconds (e.g., '30s', '120s')",
+					Severity: protocol.DiagnosticSeverityError,
+				})
+			}
+			// Check if duration exceeds 10 minutes
+			if duration > 10*time.Minute {
+				val.addDiagnostic(protocol.Diagnostic{
+					Range:    step.Range,
+					Message:  "auto_rerun_delay must not exceed 10 minutes",
+					Severity: protocol.DiagnosticSeverityError,
+				})
+			}
+		}
 	}
 
 	var value string

--- a/pkg/services/background_auto_rerun_test.go
+++ b/pkg/services/background_auto_rerun_test.go
@@ -178,6 +178,354 @@ workflows:
 			expectErrors:    true,
 			errorSubstrings: []string{"auto_rerun_delay", "max_auto_reruns"},
 		},
+		{
+			name: "Valid: max_auto_reruns minimum value (1)",
+			yamlContent: `version: 2.1
+jobs:
+  test-job:
+    docker:
+      - image: cimg/base:stable
+    steps:
+      - run:
+          name: "Task with minimum auto reruns"
+          command: "echo test"
+          max_auto_reruns: 1
+workflows:
+  test-workflow:
+    jobs:
+      - test-job`,
+			expectErrors: false,
+		},
+		{
+			name: "Valid: max_auto_reruns maximum value (5)",
+			yamlContent: `version: 2.1
+jobs:
+  test-job:
+    docker:
+      - image: cimg/base:stable
+    steps:
+      - run:
+          name: "Task with maximum auto reruns"
+          command: "echo test"
+          max_auto_reruns: 5
+workflows:
+  test-workflow:
+    jobs:
+      - test-job`,
+			expectErrors: false,
+		},
+		{
+			name: "Invalid: max_auto_reruns below minimum (0)",
+			yamlContent: `version: 2.1
+jobs:
+  test-job:
+    docker:
+      - image: cimg/base:stable
+    steps:
+      - run:
+          name: "Task with zero auto reruns"
+          command: "echo test"
+          max_auto_reruns: 0
+workflows:
+  test-workflow:
+    jobs:
+      - test-job`,
+			expectErrors:    true,
+			errorSubstrings: []string{"max_auto_reruns must be between 1 and 5"},
+		},
+		{
+			name: "Invalid: max_auto_reruns above maximum (6)",
+			yamlContent: `version: 2.1
+jobs:
+  test-job:
+    docker:
+      - image: cimg/base:stable
+    steps:
+      - run:
+          name: "Task with too many auto reruns"
+          command: "echo test"
+          max_auto_reruns: 6
+workflows:
+  test-workflow:
+    jobs:
+      - test-job`,
+			expectErrors:    true,
+			errorSubstrings: []string{"max_auto_reruns must be between 1 and 5"},
+		},
+		{
+			name: "Valid: auto_rerun_delay with seconds",
+			yamlContent: `version: 2.1
+jobs:
+  test-job:
+    docker:
+      - image: cimg/base:stable
+    steps:
+      - run:
+          name: "Task with delay in seconds"
+          command: "echo test"
+          max_auto_reruns: 2
+          auto_rerun_delay: 30s
+workflows:
+  test-workflow:
+    jobs:
+      - test-job`,
+			expectErrors: false,
+		},
+		{
+			name: "Valid: auto_rerun_delay with minutes",
+			yamlContent: `version: 2.1
+jobs:
+  test-job:
+    docker:
+      - image: cimg/base:stable
+    steps:
+      - run:
+          name: "Task with delay in minutes"
+          command: "echo test"
+          max_auto_reruns: 3
+          auto_rerun_delay: 5m
+workflows:
+  test-workflow:
+    jobs:
+      - test-job`,
+			expectErrors: false,
+		},
+		{
+			name: "Invalid: auto_rerun_delay with milliseconds",
+			yamlContent: `version: 2.1
+jobs:
+  test-job:
+    docker:
+      - image: cimg/base:stable
+    steps:
+      - run:
+          name: "Task with delay in milliseconds"
+          command: "echo test"
+          max_auto_reruns: 2
+          auto_rerun_delay: 500ms
+workflows:
+  test-workflow:
+    jobs:
+      - test-job`,
+			expectErrors:    true,
+			errorSubstrings: []string{"auto_rerun_delay must be in the format"},
+		},
+		{
+			name: "Valid: auto_rerun_delay at maximum (10m)",
+			yamlContent: `version: 2.1
+jobs:
+  test-job:
+    docker:
+      - image: cimg/base:stable
+    steps:
+      - run:
+          name: "Task with maximum delay"
+          command: "echo test"
+          max_auto_reruns: 2
+          auto_rerun_delay: 10m
+workflows:
+  test-workflow:
+    jobs:
+      - test-job`,
+			expectErrors: false,
+		},
+		{
+			name: "Valid: auto_rerun_delay in seconds (600s = 10m)",
+			yamlContent: `version: 2.1
+jobs:
+  test-job:
+    docker:
+      - image: cimg/base:stable
+    steps:
+      - run:
+          name: "Task with delay in seconds"
+          command: "echo test"
+          max_auto_reruns: 1
+          auto_rerun_delay: 600s
+workflows:
+  test-workflow:
+    jobs:
+      - test-job`,
+			expectErrors: false,
+		},
+		{
+			name: "Invalid: auto_rerun_delay exceeds maximum (11m)",
+			yamlContent: `version: 2.1
+jobs:
+  test-job:
+    docker:
+      - image: cimg/base:stable
+    steps:
+      - run:
+          name: "Task with delay over maximum"
+          command: "echo test"
+          max_auto_reruns: 2
+          auto_rerun_delay: 11m
+workflows:
+  test-workflow:
+    jobs:
+      - test-job`,
+			expectErrors:    true,
+			errorSubstrings: []string{"auto_rerun_delay must not exceed 10 minutes"},
+		},
+		{
+			name: "Invalid: auto_rerun_delay exceeds maximum (700s)",
+			yamlContent: `version: 2.1
+jobs:
+  test-job:
+    docker:
+      - image: cimg/base:stable
+    steps:
+      - run:
+          name: "Task with delay over 10m in seconds"
+          command: "echo test"
+          max_auto_reruns: 2
+          auto_rerun_delay: 700s
+workflows:
+  test-workflow:
+    jobs:
+      - test-job`,
+			expectErrors:    true,
+			errorSubstrings: []string{"auto_rerun_delay must not exceed 10 minutes"},
+		},
+		{
+			name: "Invalid: auto_rerun_delay with invalid format (no unit)",
+			yamlContent: `version: 2.1
+jobs:
+  test-job:
+    docker:
+      - image: cimg/base:stable
+    steps:
+      - run:
+          name: "Task with invalid delay format"
+          command: "echo test"
+          max_auto_reruns: 2
+          auto_rerun_delay: 30
+workflows:
+  test-workflow:
+    jobs:
+      - test-job`,
+			expectErrors:    true,
+			errorSubstrings: []string{"auto_rerun_delay must be a valid duration"},
+		},
+		{
+			name: "Invalid: auto_rerun_delay with invalid text",
+			yamlContent: `version: 2.1
+jobs:
+  test-job:
+    docker:
+      - image: cimg/base:stable
+    steps:
+      - run:
+          name: "Task with invalid delay text"
+          command: "echo test"
+          max_auto_reruns: 1
+          auto_rerun_delay: invalid
+workflows:
+  test-workflow:
+    jobs:
+      - test-job`,
+			expectErrors:    true,
+			errorSubstrings: []string{"auto_rerun_delay must be a valid duration"},
+		},
+		{
+			name: "Invalid: auto_rerun_delay with 0 seconds",
+			yamlContent: `version: 2.1
+jobs:
+  test-job:
+    docker:
+      - image: cimg/base:stable
+    steps:
+      - run:
+          name: "Task with 0 seconds delay"
+          command: "echo test"
+          max_auto_reruns: 2
+          auto_rerun_delay: 0s
+workflows:
+  test-workflow:
+    jobs:
+      - test-job`,
+			expectErrors:    true,
+			errorSubstrings: []string{"auto_rerun_delay must be in the format"},
+		},
+		{
+			name: "Invalid: auto_rerun_delay with 0 minutes",
+			yamlContent: `version: 2.1
+jobs:
+  test-job:
+    docker:
+      - image: cimg/base:stable
+    steps:
+      - run:
+          name: "Task with 0 minutes delay"
+          command: "echo test"
+          max_auto_reruns: 2
+          auto_rerun_delay: 0m
+workflows:
+  test-workflow:
+    jobs:
+      - test-job`,
+			expectErrors:    true,
+			errorSubstrings: []string{"auto_rerun_delay must be in the format"},
+		},
+		{
+			name: "Invalid: auto_rerun_delay with both minutes and seconds",
+			yamlContent: `version: 2.1
+jobs:
+  test-job:
+    docker:
+      - image: cimg/base:stable
+    steps:
+      - run:
+          name: "Task with both minutes and seconds"
+          command: "echo test"
+          max_auto_reruns: 2
+          auto_rerun_delay: 1m30s
+workflows:
+  test-workflow:
+    jobs:
+      - test-job`,
+			expectErrors:    true,
+			errorSubstrings: []string{"auto_rerun_delay must be in the format"},
+		},
+		{
+			name: "Valid: auto_rerun_delay edge case (1s)",
+			yamlContent: `version: 2.1
+jobs:
+  test-job:
+    docker:
+      - image: cimg/base:stable
+    steps:
+      - run:
+          name: "Task with minimum delay"
+          command: "echo test"
+          max_auto_reruns: 1
+          auto_rerun_delay: 1s
+workflows:
+  test-workflow:
+    jobs:
+      - test-job`,
+			expectErrors: false,
+		},
+		{
+			name: "Valid: auto_rerun_delay edge case (9m)",
+			yamlContent: `version: 2.1
+jobs:
+  test-job:
+    docker:
+      - image: cimg/base:stable
+    steps:
+      - run:
+          name: "Task with 9 minute delay"
+          command: "echo test"
+          max_auto_reruns: 2
+          auto_rerun_delay: 9m
+workflows:
+  test-workflow:
+    jobs:
+      - test-job`,
+			expectErrors: false,
+		},
 	}
 
 	for _, tc := range testCases {

--- a/publicschema.json
+++ b/publicschema.json
@@ -656,7 +656,7 @@
                                 "auto_rerun_delay": {
                                     "description": "Delay before automatic rerun of this step",
                                     "type": "string",
-                                    "pattern": "^(10|[1-9])m$"
+                                    "pattern": "^(10|[1-9])m|([1-9][0-9]*)s$"
                                 }
                             },
                             "if": {


### PR DESCRIPTION
[Jira](https://circleci.atlassian.net/browse/PIPE-5246)

# Description

Add validation for step rerun fields: 
- `max_auto_reruns` - value is between 1 and 5
- `auto_rerun_delay` - value should be in a duration format, not longer than 10 minutes, and should conform to `(10|[1-9])m|([1-9][0-9]*)s` regex (be in the form of either minutes or seconds)

# How to validate

unit tests

