### PR TITLE
chore(server): Add new Q3 linux images

### DIFF
--- a/pkg/utils/executors.go
+++ b/pkg/utils/executors.go
@@ -36,6 +36,7 @@ var ValidLinuxImages = []string{
 	"ubuntu-2004:edge",
 
 	// Ubuntu 22.04
+	"ubuntu-2204:2025.09.1",
 	"ubuntu-2204:2024.11.1",
 	"ubuntu-2204:2024.08.1",
 	"ubuntu-2204:2024.05.1",
@@ -57,6 +58,7 @@ var ValidLinuxImages = []string{
 	"ubuntu-2204:edge",
 
 	// Ubuntu 24.04
+	"ubuntu-2404:2025.09.1",
 	"ubuntu-2404:2024.11.1",
 	"ubuntu-2404:2024.08.1",
 	"ubuntu-2404:2024.05.1",
@@ -157,6 +159,10 @@ var ValidLinuxGPUImages = []string{
 	// CUDA 12
 	"linux-cuda-12:default",
 	"linux-cuda-12:edge",
+
+	// CUDA 13
+	// "linux-cuda-13:default",
+	"linux-cuda-13:edge",
 }
 
 var ValidLinuxGPUResourceClasses = []string{


### PR DESCRIPTION
# Description
This PR adds new Linux images for 2025 Q3
- https://circleci.com/developer/machine/image/ubuntu-2204

# Implementation details
Added new image to existing array of images for Q3 2025 release cycle

# How to validate
Here's a quick usage example with "Hello World" configuration:
```yaml
version: 2.1
jobs:
  build:
    machine:
      image: 'ubuntu-2204:2025.09.1'
      resource_class: medium
    steps:
      - run: echo 'Hello World'
      - run: |
          echo "Linux system information:"
          echo "Hello World from Linux 2025 Q3!"
```