### PR TITLE
PIPE-5019 Handle `no-op`, `approval`, and `release` job types

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,6 +33,11 @@ orbs:
   slack: circleci/slack@4.12.1
   github-cli: circleci/github-cli@2.2.0
 
+executors:
+  go-executor:
+    docker:
+      - image: cimg/go:1.23.4
+
 commands:
   install-zig:
     steps:
@@ -174,8 +179,7 @@ commands:
 
 jobs:
   Create version file:
-    docker:
-      - image: cimg/go:1.22.3
+    executor: go-executor
     description: |
       Create a version to be used by the /scripts/ldflags.sh when building the binaries
     parameters:
@@ -210,8 +214,7 @@ jobs:
   Unit Tests:
     environment:
       SCHEMA_LOCATION: /home/circleci/project/schema.json
-    docker:
-      - image: cimg/go:1.22.3
+    executor: go-executor
     parallelism: 5
     steps:
       - checkout
@@ -231,8 +234,7 @@ jobs:
         type: string
       arch:
         type: string
-    docker:
-      - image: cimg/go:1.22.3
+    executor: go-executor
     resource_class: << parameters.resource_class >>
     steps:
       - attach_workspace:
@@ -277,8 +279,7 @@ jobs:
             - project/bin
 
   Build Windows:
-    docker:
-      - image: cimg/go:1.22.3
+    executor: go-executor
     steps:
       - attach_workspace:
           at: ~/
@@ -347,8 +348,7 @@ jobs:
           path: /tmp/circleci-lsp-vsix.zip
 
   Lint:
-    docker:
-      - image: cimg/go:1.22.3
+    executor: go-executor
     steps:
       - checkout
       - run:
@@ -400,8 +400,7 @@ jobs:
               --manifest-file .circleci/release/release-please-manifest.json
 
   Pre-Release:
-    docker:
-      - image: cimg/go:1.22.3
+    executor: go-executor
     steps:
       - checkout
       - attach_workspace:
@@ -487,8 +486,7 @@ jobs:
           destination: .
 
   Security Scan release:
-    docker:
-      - image: cimg/go:1.22.3
+    executor: go-executor
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,7 @@ orbs:
 executors:
   go-executor:
     docker:
-      - image: cimg/go:1.23.4
+      - image: cimg/go:1.25.0
 
 commands:
   install-zig:

--- a/HACKING.md
+++ b/HACKING.md
@@ -13,7 +13,7 @@ resources:
 
 ## Requirements
 
--   Go 1.19+
+-   Go 1.23+
 -   [Task](https://taskfile.dev/)
 -   [detect-secrets](https://github.com/Yelp/detect-secrets)
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -63,9 +63,7 @@ tasks:
       SCHEMA_LOCATION: ./publicschema.json
 
   init:
-      - go install github.com/automation-co/husky@latest
-      - go get -d ./...
-      - husky install
+    - go mod download
 
   licenses:
       - go-licenses csv ./cmd/start_server >licenses.csv 2>licenses.errors

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -59,14 +59,14 @@ tasks:
     cmds:
       - ./bin/start_server
     env:
-      PORT: '{{.PORT | default 10001}}'
+      PORT: "{{.PORT | default 10001}}"
       SCHEMA_LOCATION: ./publicschema.json
 
   init:
     - go mod download
 
   licenses:
-      - go-licenses csv ./cmd/start_server >licenses.csv 2>licenses.errors
+    - go-licenses csv ./cmd/start_server >licenses.csv 2>licenses.errors
 
   lint:
     cmds:

--- a/pkg/ast/job.go
+++ b/pkg/ast/job.go
@@ -49,6 +49,9 @@ type Job struct {
 	RetentionRange protocol.Range
 
 	CompletionItem *[]protocol.CompletionItem
+
+	Type      string
+	TypeRange protocol.Range
 }
 
 func (job *Job) AddCompletionItem(label string, commitCharacters []string) {

--- a/pkg/parser/jobs.go
+++ b/pkg/parser/jobs.go
@@ -121,6 +121,10 @@ func (doc *YamlDocument) parseSingleJob(jobNode *sitter.Node) ast.Job {
 				blockMapping := GetChildMapping(valueNode)
 				res.Environment = doc.parseDictionary(blockMapping)
 				res.EnvironmentRange = doc.NodeToRange(child)
+
+			case "type":
+				res.Type = doc.GetNodeText(valueNode)
+				res.TypeRange = doc.NodeToRange(child)
 			}
 		}
 	})

--- a/pkg/parser/jobs.go
+++ b/pkg/parser/jobs.go
@@ -158,4 +158,7 @@ func (doc *YamlDocument) jobCompletionItem(job ast.Job) {
 	if job.Parallelism == 0 {
 		job.AddCompletionItem("parallelism", []string{":", " "})
 	}
+	if job.Type == "" {
+		job.AddCompletionItem("type", []string{":", " "})
+	}
 }

--- a/pkg/parser/jobs_test.go
+++ b/pkg/parser/jobs_test.go
@@ -27,6 +27,7 @@ func getJobsTests() []struct {
 			args: jobsArgs{
 				jobsString: `jobs:
     test:
+        type: build
         parallelism: 2
         working_directory: "~/testJob"
         shell: "superShell"
@@ -44,6 +45,7 @@ func getJobsTests() []struct {
 					WorkingDirectory: "~/testJob",
 					Shell:            "superShell",
 					ResourceClass:    "superFast",
+					Type:             "build",
 				},
 			},
 		},

--- a/pkg/parser/validate/jobs_test.go
+++ b/pkg/parser/validate/jobs_test.go
@@ -1,6 +1,7 @@
 package validate
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/CircleCI-Public/circleci-yaml-language-server/pkg/parser"
@@ -275,6 +276,104 @@ func TestRetention(t *testing.T) {
 				}
 			}
 			t.Fatalf(`missing retention diagnostic for test case: %s`, testCase.label)
+		})
+	}
+}
+
+func TestJobTypeValidation(t *testing.T) {
+	// WARNING: be careful when editing the `yamlData` strings as they are sensitive to tabs vs spaces
+
+	testCases := []struct {
+		label        string
+		yamlData     string
+		expectedDiag protocol.Diagnostic
+	}{
+		{
+			label: "explicitly defining type as build gives a hint",
+			yamlData: `jobs:
+  my-job:
+    type: build
+`,
+			expectedDiag: protocol.Diagnostic{
+				Range: protocol.Range{
+					Start: protocol.Position{Line: 2, Character: 4},
+					End:   protocol.Position{Line: 2, Character: 15},
+				},
+				Severity: protocol.DiagnosticSeverityHint,
+				Message:  "If no `type:` key is specified, the job will default to `type: build`.",
+			},
+		},
+		{
+			label: "invalid job type should give an error",
+			yamlData: `jobs:
+  my-job:
+    type: bad-type
+`,
+			expectedDiag: protocol.Diagnostic{
+				Range: protocol.Range{
+					Start: protocol.Position{Line: 2, Character: 4},
+					End:   protocol.Position{Line: 2, Character: 18},
+				},
+				Severity: protocol.DiagnosticSeverityError,
+				Message:  "Invalid job type 'bad-type'. Allowed types: approval, build, no-op, release",
+			},
+		},
+		{
+			label: "putting `steps`: in a job type that doesn't use it will give a warning",
+			yamlData: `jobs:
+  my-job:
+    type: approval
+    steps:
+      - checkout`,
+			expectedDiag: protocol.Diagnostic{
+				Range: protocol.Range{
+					Start: protocol.Position{Line: 3, Character: 4},
+					End:   protocol.Position{Line: 4, Character: 16},
+				},
+				Severity: protocol.DiagnosticSeverityWarning,
+				Message:  "If job type is approval, no-op or release, then steps will be ignored.",
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run("validate job type: "+testCase.label, func(t *testing.T) {
+			ctx := &utils.LsContext{
+				Api: utils.ApiContext{
+					Token:   "XXXXXXXXXXXX",
+					HostUrl: "https://circleci.com",
+				},
+			}
+			doc, err := parser.ParseFromContent(
+				[]byte(testCase.yamlData),
+				ctx,
+				uri.URI(""),
+				protocol.Position{},
+			)
+			assert.NoError(t, err, "invalid YAML data")
+
+			val := Validate{
+				APIs:        ValidateAPIs{DockerHubMock{}},
+				Context:     ctx,
+				Doc:         doc,
+				Diagnostics: &[]protocol.Diagnostic{},
+				Cache:       utils.CreateCache(),
+			}
+
+			val.Validate()
+
+			diagnostics := ""
+			for _, diag := range *val.Diagnostics {
+				formattedDiag := fmt.Sprintf("%v\n", diag)
+				diagnostics = diagnostics + formattedDiag
+				if diag.Range == testCase.expectedDiag.Range &&
+					diag.Severity == testCase.expectedDiag.Severity &&
+					diag.Message == testCase.expectedDiag.Message {
+					return
+				}
+			}
+
+			t.Fatalf("missing type validation diagnostic for test case: %s\n\nEmitted diagnostic:\n%v\nExpected diagnostic:\n%v", testCase.label, diagnostics, testCase.expectedDiag)
 		})
 	}
 }

--- a/pkg/parser/validate/workflow.go
+++ b/pkg/parser/validate/workflow.go
@@ -35,7 +35,7 @@ func (val Validate) validateSingleWorkflow(workflow ast.Workflow) error {
 
 		jobTypeIsDefined := jobRef.Type != ""
 		if jobTypeIsDefined {
-			val.addDiagnostic(utils.CreateErrorDiagnosticFromRange(jobRef.TypeRange, "Type can only be \"approval\""))
+			val.addDiagnostic(utils.CreateErrorDiagnosticFromRange(jobRef.TypeRange, fmt.Sprintf("Jobs defined inline under the `workflows:` section can only have `type: approval`. If you want a different job type, please put the `type: %s` mapping under your job in the `jobs:` section of your config instead.", jobRef.Type)))
 			continue
 		}
 

--- a/pkg/parser/validate/workflow_test.go
+++ b/pkg/parser/validate/workflow_test.go
@@ -42,7 +42,7 @@ workflows:
 				utils.CreateErrorDiagnosticFromRange(protocol.Range{
 					Start: protocol.Position{Line: 0x6, Character: 0x10},
 					End:   protocol.Position{Line: 0x6, Character: 0x17},
-				}, "Type can only be \"approval\""),
+				}, "Jobs defined inline under the `workflows:` section can only have `type: approval`. If you want a different job type, please put the `type: invalid` mapping under your job in the `jobs:` section of your config instead."),
 			},
 		},
 		{

--- a/pkg/services/complete_test.go
+++ b/pkg/services/complete_test.go
@@ -122,6 +122,11 @@ func TestComplete(t *testing.T) {
 					InsertText: "shell: ",
 					Kind:       protocol.CompletionItemKindProperty,
 				},
+				{
+					Label:      "type",
+					InsertText: "type: ",
+					Kind:       protocol.CompletionItemKindProperty,
+				},
 			},
 		},
 		{

--- a/pkg/utils/jobs.go
+++ b/pkg/utils/jobs.go
@@ -15,3 +15,11 @@ func HasStoreTestResultStep(step []ast.Step) bool {
 	}
 	return false
 }
+
+// JobTypes is a list of all valid job types that are supported by CircleCI
+var JobTypes = []string{
+	"approval",
+	"build", // default
+	"no-op",
+	"release",
+}

--- a/publicschema.json
+++ b/publicschema.json
@@ -1120,7 +1120,7 @@
                     "default": "org-global"
                 },
                 "type": {
-                    "description": "A job may have a `type` of `approval` indicating it must be manually approved before downstream jobs may proceed.",
+                    "description": "A job defined under the `workflows:` section may specify a type but it can only be `approval`.\n`approval` jobs must be manually approved before downstream jobs may proceed.\nFor [other job types](https://circleci.com/docs/reference/configuration-reference/#job-type), they must be specified under the `jobs:` section. Please see the [`type` under `workflows:` docs](https://circleci.com/docs/reference/configuration-reference/#type) for more information.",
                     "enum": [
                         "approval"
                     ]
@@ -1215,6 +1215,10 @@
                     "steps"
                 ],
                 "properties": {
+                    "type": {
+                        "description": "[Job Types](https://circleci.com/docs/reference/configuration-reference/#job-type)\nSome examples are `build`, `approval`, `no-op`, `release`.",
+                        "type": "string"
+                    },
                     "shell": {
                         "description": "Shell to use for execution command in all steps. Can be overridden by shell in each step",
                         "type": "string"

--- a/schema.json
+++ b/schema.json
@@ -1726,6 +1726,10 @@
 							"description": {
 								"type": "string"
 							},
+							"type": {
+								"type": "string",
+								"description": "The job type. Further validation is handled by the language server."
+							},
 							"parallelism": {
 								"description": "A integer or a parameter evaluating to a integer",
 								"anyOf": [
@@ -2121,6 +2125,17 @@
 								]
 							}
 						]
+					},
+					{
+						"title": "Job with type explicitly specified. Some job types like approval or no-op don't require steps or executors defined to be valid, so this rule allows them to be omitted if type is specified.",
+						"type": "object",
+						"additionalProperties": false,
+						"properties": {
+							"type": {
+								"type": "string",
+								"description": "The job type. Further validation is handled by the language server."
+							}
+						}
 					},
 					{
 						"type": "string",


### PR DESCRIPTION
[Jira](https://circleci.atlassian.net/browse/PIPE-5019)

# Description

## Overview

This PR adds missing validations for specifying job types both within `workflows:` and `jobs:`. It also adds tests for new validations!

Users can define the job type under the `jobs:` section with the following format:

```yaml
jobs:
  my-job:
    type: no-op
```

Here are the job types allowed to be specified under the `jobs: type:` key:

- `no-op`
- `build` (this is the default if type is left unspecified
- `approval`
- `release`

It is also possible to specify `type:` under the `workflows:` section. However, according to [this ticket](https://circleci.atlassian.net/browse/PIPE-4923), we should only allow `type` to be specified inline in workflow config for `approval` jobs. This is more for backwards-compatability; and the recommendation is to put `type: approval` under the `jobs:` section like all the other job types.

## Added Hovers

Two hovers were added to `publicschema.json` that the Red Hat Yaml Language Server will display for the user:

### `type:` specified under `workflows:`

```yaml
workflows:
  build-workflow:
    jobs:
      - workflow-approval-job: 
          type: approval # <---------- hover over this
```

When hovering over `type:`, the user will see:

<img width="1475" height="179" alt="image" src="https://github.com/user-attachments/assets/d5e84409-81ee-4202-b0cb-6f3fc7a5bc39" />


### `type:` specified under `jobs:`

When hovering over `type:` under the `jobs:` section, it will link to documentation and list some examples of possible values.

<img width="731" height="135" alt="image" src="https://github.com/user-attachments/assets/d14f1474-1053-4cc4-835c-1ac99be91150" />

## New JSON schema validation

Modified `schema.json` (which is what schemastore points to) to allow users to specify type under the `jobs:` section.

The following two forms are now valid:

1. a job with just a type specified (`no-op` for example). Before it would yell at you that you need steps
2. a job with type specified along with steps, machine, docker, etc.
    - in this scenario you could either explicitly mark a job with `type: build`
    - or, it is technically valid to have a `type: approval` with steps defined, we just ignore the steps
      - in this scenario, I have added a warning to the LSP, more that below 

## Go/language server based validations

### user specifies a type other than `approval` under `workflows:`

```yaml
workflows:
  build-workflow:
    jobs:
      - workflow-no-op-job: 
          type: no-op 
```

now gives the following dynamic error:

<img width="1410" height="219" alt="image" src="https://github.com/user-attachments/assets/df29f6c3-9df9-4fbc-83f7-5bb6ccd23504" />
 
### Validate the allowed types under the `jobs:` section.

Adds an error if you try to use a type that isn't valid:

<img width="1079" height="126" alt="image" src="https://github.com/user-attachments/assets/74377a37-75e0-4c9e-9dca-5f460e164d58" />

### Throw a warning if the user tries to use `steps:` in a job marked as `approval`, `no-op` or `release`

<img width="1079" height="178" alt="image" src="https://github.com/user-attachments/assets/e09cc3d9-84b3-4849-8bec-bb570d087e2c" />

# How to validate

Follow the steps in `HACKING.md` to use the changes in VScode locally.

# Other info

- Updated the CCI config to clean up our Go executor versions from one of @meeech's commits back in April
- Removed the `Taskfile.yaml`'s reference to Husky in the init step as we weren't using it
- Can probably close #333 and #330 as this implements both

