### PR TITLE
feat: Add lock jobs and improve job JSON schema validations

### DIFF
--- a/pkg/ast/job.go
+++ b/pkg/ast/job.go
@@ -52,6 +52,12 @@ type Job struct {
 
 	Type      string
 	TypeRange protocol.Range
+
+	PlanName      string
+	PlanNameRange protocol.Range
+
+	Key      string
+	KeyRange protocol.Range
 }
 
 func (job *Job) AddCompletionItem(label string, commitCharacters []string) {

--- a/pkg/parser/jobs.go
+++ b/pkg/parser/jobs.go
@@ -125,6 +125,15 @@ func (doc *YamlDocument) parseSingleJob(jobNode *sitter.Node) ast.Job {
 			case "type":
 				res.Type = doc.GetNodeText(valueNode)
 				res.TypeRange = doc.NodeToRange(child)
+
+			case "plan_name":
+				res.PlanName = doc.GetNodeText(valueNode)
+				res.PlanNameRange = doc.NodeToRange(child)
+
+			case "key":
+				res.Key = doc.GetNodeText(valueNode)
+				res.KeyRange = doc.NodeToRange(child)
+
 			}
 		}
 	})
@@ -164,5 +173,11 @@ func (doc *YamlDocument) jobCompletionItem(job ast.Job) {
 	}
 	if job.Type == "" {
 		job.AddCompletionItem("type", []string{":", " "})
+	}
+	if job.PlanName == "" {
+		job.AddCompletionItem("plan_name", []string{":", " "})
+	}
+	if job.Key == "" {
+		job.AddCompletionItem("key", []string{":", " "})
 	}
 }

--- a/pkg/parser/jsonschema_test.go
+++ b/pkg/parser/jsonschema_test.go
@@ -1,6 +1,7 @@
 package parser
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/CircleCI-Public/circleci-yaml-language-server/pkg/expect"
@@ -71,4 +72,262 @@ test:
 	}
 
 	expect.DiagnosticList(t, diagnostics).To.Include(expected)
+}
+
+func Test_JobDefinitionTypes(t *testing.T) {
+	testCases := []struct {
+		name                string
+		yaml                string
+		expectError         bool
+		expectErrorContains string
+	}{
+		// Build type tests
+		{
+			name: "build type - valid with docker and steps",
+			yaml: `
+version: 2.1
+jobs:
+  my-build-job:
+    type: build
+    docker:
+      - image: cimg/base:2023.01
+    steps:
+      - checkout
+`,
+			expectError: false,
+		},
+		{
+			name: "build type - valid with explicit type",
+			yaml: `
+version: 2.1
+jobs:
+  my-build-job:
+    type: build
+    docker:
+      - image: cimg/base:2023.01
+    steps:
+      - checkout
+      - run: echo "build job with explicit type"
+`,
+			expectError: false,
+		},
+		{
+			name: "build type - missing steps (should error)",
+			yaml: `
+version: 2.1
+jobs:
+  my-build-job:
+    type: build
+    docker:
+      - image: cimg/base:2023.01
+`,
+			expectError:         true,
+			expectErrorContains: "steps",
+		},
+
+		// Release type tests
+		{
+			name: "release type - valid with plan_name",
+			yaml: `
+version: 2.1
+jobs:
+  my-release-job:
+    type: release
+    plan_name: my-release-plan
+`,
+			expectError: false,
+		},
+		{
+			name: "release type - valid with additional properties",
+			yaml: `
+version: 2.1
+jobs:
+  my-release-job:
+    type: release
+    plan_name: my-plan
+    some_other_property: allowed
+`,
+			expectError: false,
+		},
+		{
+			name: "release type - missing plan_name (should error)",
+			yaml: `
+version: 2.1
+jobs:
+  my-release-job:
+    type: release
+`,
+			expectError:         true,
+			expectErrorContains: "plan_name",
+		},
+
+		// Lock type tests
+		{
+			name: "lock type - valid with key",
+			yaml: `
+version: 2.1
+jobs:
+  my-lock-job:
+    type: lock
+    key: my-lock-key
+`,
+			expectError: false,
+		},
+		{
+			name: "lock type - valid with additional properties",
+			yaml: `
+version: 2.1
+jobs:
+  my-lock-job:
+    type: lock
+    key: my-key
+    some_other_property: allowed
+`,
+			expectError: false,
+		},
+		{
+			name: "lock type - missing key (should error)",
+			yaml: `
+version: 2.1
+jobs:
+  my-lock-job:
+    type: lock
+`,
+			expectError:         true,
+			expectErrorContains: "key",
+		},
+
+		// Unlock type tests
+		{
+			name: "unlock type - valid with key",
+			yaml: `
+version: 2.1
+jobs:
+  my-unlock-job:
+    type: unlock
+    key: my-lock-key
+`,
+			expectError: false,
+		},
+		{
+			name: "unlock type - valid with additional properties",
+			yaml: `
+version: 2.1
+jobs:
+  my-unlock-job:
+    type: unlock
+    key: my-key
+    some_other_property: allowed
+`,
+			expectError: false,
+		},
+		{
+			name: "unlock type - missing key (should error)",
+			yaml: `
+version: 2.1
+jobs:
+  my-unlock-job:
+    type: unlock
+`,
+			expectError:         true,
+			expectErrorContains: "key",
+		},
+
+		// Approval type tests
+		{
+			name: "approval type - valid minimal",
+			yaml: `
+version: 2.1
+jobs:
+  my-approval-job:
+    type: approval
+`,
+			expectError: false,
+		},
+		{
+			name: "approval type - valid with steps (ignored)",
+			yaml: `
+version: 2.1
+jobs:
+  my-approval-job:
+    type: approval
+    steps:
+      - run: echo "This will be ignored"
+`,
+			expectError: false,
+		},
+
+		// No-op type tests
+		{
+			name: "no-op type - valid minimal",
+			yaml: `
+version: 2.1
+jobs:
+  my-noop-job:
+    type: no-op
+`,
+			expectError: false,
+		},
+		{
+			name: "no-op type - valid with steps (ignored)",
+			yaml: `
+version: 2.1
+jobs:
+  my-noop-job:
+    type: no-op
+    steps:
+      - run: echo "This will be ignored"
+`,
+			expectError: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			context := testHelpers.GetDefaultLsContext()
+			yamlDocument, _ := ParseFromContent([]byte(tc.yaml), context, uri.File(""), protocol.Position{})
+
+			if tc.expectError {
+				// For error cases, also run JSON schema validation
+				validator := JSONSchemaValidator{
+					Doc: yamlDocument,
+				}
+
+				schemaPath := "../../schema.json"
+				err := validator.LoadJsonSchema(schemaPath)
+				if err != nil {
+					t.Logf("Warning: Could not load schema: %v", err)
+					t.SkipNow()
+				}
+
+				diagnostics := validator.ValidateWithJSONSchema(yamlDocument.RootNode, yamlDocument.Content)
+
+				// Log all diagnostics for debugging
+				if len(diagnostics) > 0 {
+					t.Logf("Found %d diagnostic(s):", len(diagnostics))
+					for _, d := range diagnostics {
+						t.Logf("  - %s", d.Message)
+					}
+				} else {
+					t.Logf("No diagnostics found")
+				}
+
+				assert.NotEmpty(t, diagnostics, "Expected validation errors but got none")
+				if tc.expectErrorContains != "" {
+					found := false
+					for _, d := range diagnostics {
+						if strings.Contains(strings.ToLower(d.Message), strings.ToLower(tc.expectErrorContains)) {
+							found = true
+							break
+						}
+					}
+					assert.True(t, found, "Expected error message to contain '%s'", tc.expectErrorContains)
+				}
+			} else {
+				// For non-error cases, just check that parsing succeeded
+				diagnostics := yamlDocument.Diagnostics
+				assert.Empty(t, diagnostics, "Expected no errors but got: %v", diagnostics)
+			}
+		})
+	}
 }

--- a/pkg/parser/validate/jobs.go
+++ b/pkg/parser/validate/jobs.go
@@ -21,11 +21,11 @@ func (val Validate) validateSingleJob(job ast.Job) {
 
 	val.validateSteps(job.Steps, job.Name, job.Parameters)
 
-	if job.Steps != nil && (job.Type == "approval" || job.Type == "no-op" || job.Type == "release") {
+	if job.Steps != nil && job.Type != "" && job.Type != "build" {
 		val.addDiagnostic(
 			protocol.Diagnostic{
 				Range:    job.StepsRange,
-				Message:  "If job type is approval, no-op or release, then steps will be ignored.",
+				Message:  "Steps only exist in `build` jobs. Steps here will be ignored.",
 				Severity: protocol.DiagnosticSeverityWarning,
 			},
 		)

--- a/pkg/parser/validate/jobs_test.go
+++ b/pkg/parser/validate/jobs_test.go
@@ -315,7 +315,7 @@ func TestJobTypeValidation(t *testing.T) {
 					End:   protocol.Position{Line: 2, Character: 18},
 				},
 				Severity: protocol.DiagnosticSeverityError,
-				Message:  "Invalid job type 'bad-type'. Allowed types: approval, build, no-op, release",
+				Message:  "Invalid job type 'bad-type'. Allowed types: approval, build, no-op, release, lock, unlock",
 			},
 		},
 		{
@@ -331,7 +331,7 @@ func TestJobTypeValidation(t *testing.T) {
 					End:   protocol.Position{Line: 4, Character: 16},
 				},
 				Severity: protocol.DiagnosticSeverityWarning,
-				Message:  "If job type is approval, no-op or release, then steps will be ignored.",
+				Message:  "Steps only exist in `build` jobs. Steps here will be ignored.",
 			},
 		},
 	}

--- a/pkg/services/complete/jobs.go
+++ b/pkg/services/complete/jobs.go
@@ -33,6 +33,9 @@ func (ch *CompletionHandler) completeJobs() {
 	case utils.PosInRange(job.DockerRange, ch.Params.Position):
 		ch.completeDockerExecutor(job.Docker)
 		return
+	case utils.PosInRange(job.TypeRange, ch.Params.Position):
+		ch.addJobTypeCompletion()
+		return
 	}
 
 	ch.Items = append(ch.Items, (*job.CompletionItem)...)
@@ -77,4 +80,10 @@ func findJob(pos protocol.Position, doc yamlparser.YamlDocument) (ast.Job, error
 		}
 	}
 	return ast.Job{}, fmt.Errorf("no job found")
+}
+
+func (ch *CompletionHandler) addJobTypeCompletion() {
+	for _, jobType := range utils.JobTypes {
+		ch.addCompletionItem(jobType)
+	}
 }

--- a/pkg/services/complete_test.go
+++ b/pkg/services/complete_test.go
@@ -127,6 +127,16 @@ func TestComplete(t *testing.T) {
 					InsertText: "type: ",
 					Kind:       protocol.CompletionItemKindProperty,
 				},
+				{
+					Label:      "plan_name",
+					InsertText: "plan_name: ",
+					Kind:       protocol.CompletionItemKindProperty,
+				},
+				{
+					Label:      "key",
+					InsertText: "key: ",
+					Kind:       protocol.CompletionItemKindProperty,
+				},
 			},
 		},
 		{

--- a/pkg/utils/jobs.go
+++ b/pkg/utils/jobs.go
@@ -22,4 +22,6 @@ var JobTypes = []string{
 	"build", // default
 	"no-op",
 	"release",
+	"lock",
+	"unlock",
 }

--- a/publicschema.json
+++ b/publicschema.json
@@ -1223,7 +1223,7 @@
                     ],
                     "properties": {
                         "type": {
-                            "description": "[Job Types](https://circleci.com/docs/reference/configuration-reference/#job-type)\nSome examples are `build`, `approval`, `no-op`, `release`.",
+                            "description": "[Job Types](https://circleci.com/docs/reference/configuration-reference/#job-type)\nThe job type. If not specified, defaults to `build`.",
                             "type": "string"
                         },
                         "shell": {

--- a/publicschema.json
+++ b/publicschema.json
@@ -663,10 +663,14 @@
                                 "properties": {
                                     "auto_rerun_delay": true
                                 },
-                                    "required": ["auto_rerun_delay"]
+                                "required": [
+                                    "auto_rerun_delay"
+                                ]
                             },
                             "then": {
-                                "required": ["max_auto_reruns"]
+                                "required": [
+                                    "max_auto_reruns"
+                                ]
                             }
                         }
                     ]
@@ -691,692 +695,693 @@
                         "method": {
                             "description": "The checkout method to be used ('blobless' or 'full', default 'full')",
                             "type": "string"
-                    }
-                },
-                "setup_remote_docker": {
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/builtinSteps/documentation/setup_remote_docker"
                         }
-                    ],
-                    "type": "object",
-                    "additionalProperties": false,
-                    "properties": {
-                        "name": {
-                            "description": "Title of the step to be shown in the CircleCI UI",
-                            "type": "string"
-                        },
-                        "docker_layer_caching": {
-                            "description": "When `docker_layer_caching` is set to `true`, CircleCI will try to reuse Docker Images (layers) built during a previous job or workflow (Paid feature)",
-                            "type": "boolean",
-                            "default": false
-                        },
-                        "version": {
-                            "description": "If your build requires a specific docker image, you can set it as an image attribute",
-                            "anyOf": [
-                                {
-                                    "type": "string",
-                                    "enum": [
-                                        "20.10.24",
-                                        "20.10.23",
-                                        "20.10.18",
-                                        "20.10.17",
-                                        "20.10.14",
-                                        "20.10.12",
-                                        "20.10.11",
-                                        "20.10.7",
-                                        "20.10.6",
-                                        "20.10.2",
-                                        "19.03.13"
-                                    ]
-                                },
-                                {
-                                    "type": "string"
-                                }
-                            ]
-                        }
-                    }
-                },
-                "save_cache": {
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/builtinSteps/documentation/save_cache"
-                        }
-                    ],
-                    "type": "object",
-                    "additionalProperties": false,
-                    "required": [
-                        "paths",
-                        "key"
-                    ],
-                    "properties": {
-                        "paths": {
-                            "description": "List of directories which should be added to the cache",
-                            "type": "array",
-                            "items": {
+                    },
+                    "setup_remote_docker": {
+                        "allOf": [
+                            {
+                                "$ref": "#/definitions/builtinSteps/documentation/setup_remote_docker"
+                            }
+                        ],
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "name": {
+                                "description": "Title of the step to be shown in the CircleCI UI",
                                 "type": "string"
-                            }
-                        },
-                        "key": {
-                            "description": "Unique identifier for this cache",
-                            "type": "string"
-                        },
-                        "name": {
-                            "type": "string",
-                            "description": "Title of the step to be shown in the CircleCI UI (default: 'Saving Cache')"
-                        },
-                        "when": {
-                            "description": "Specify when to enable or disable the step. Takes the following values: `always`, `on_success`, `on_fail` (default: `on_success`)",
-                            "enum": [
-                                "always",
-                                "on_success",
-                                "on_fail"
-                            ]
-                        }
-                    }
-                },
-                "restore_cache": {
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/builtinSteps/documentation/restore_cache"
-                        }
-                    ],
-                    "oneOf": [
-                        {
-                            "type": "object",
-                            "additionalProperties": false,
-                            "required": [
-                                "key"
-                            ],
-                            "properties": {
-                                "key": {
-                                    "type": "string",
-                                    "description": "Single cache key to restore"
-                                },
-                                "name": {
-                                    "type": "string",
-                                    "description": "Title of the step to be shown in the CircleCI UI (default: 'Restoring Cache')"
-                                }
-                            }
-                        },
-                        {
-                            "type": "object",
-                            "additionalProperties": false,
-                            "required": [
-                                "keys"
-                            ],
-                            "properties": {
-                                "name": {
-                                    "type": "string",
-                                    "description": "Title of the step to be shown in the CircleCI UI (default: 'Restoring Cache')"
-                                },
-                                "keys": {
-                                    "description": "List of cache keys to lookup for a cache to restore. Only first existing key will be restored.",
-                                    "type": "array",
-                                    "items": {
+                            },
+                            "docker_layer_caching": {
+                                "description": "When `docker_layer_caching` is set to `true`, CircleCI will try to reuse Docker Images (layers) built during a previous job or workflow (Paid feature)",
+                                "type": "boolean",
+                                "default": false
+                            },
+                            "version": {
+                                "description": "If your build requires a specific docker image, you can set it as an image attribute",
+                                "anyOf": [
+                                    {
+                                        "type": "string",
+                                        "enum": [
+                                            "20.10.24",
+                                            "20.10.23",
+                                            "20.10.18",
+                                            "20.10.17",
+                                            "20.10.14",
+                                            "20.10.12",
+                                            "20.10.11",
+                                            "20.10.7",
+                                            "20.10.6",
+                                            "20.10.2",
+                                            "19.03.13"
+                                        ]
+                                    },
+                                    {
                                         "type": "string"
                                     }
+                                ]
+                            }
+                        }
+                    },
+                    "save_cache": {
+                        "allOf": [
+                            {
+                                "$ref": "#/definitions/builtinSteps/documentation/save_cache"
+                            }
+                        ],
+                        "type": "object",
+                        "additionalProperties": false,
+                        "required": [
+                            "paths",
+                            "key"
+                        ],
+                        "properties": {
+                            "paths": {
+                                "description": "List of directories which should be added to the cache",
+                                "type": "array",
+                                "items": {
+                                    "type": "string"
                                 }
-                            }
-                        }
-                    ]
-                },
-                "deploy": {
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/builtinSteps/documentation/deploy"
-                        },
-                        {
-                            "$ref": "#/definitions/builtinSteps/configuration/run"
-                        }
-                    ]
-                },
-                "store_artifacts": {
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/builtinSteps/documentation/store_artifacts"
-                        }
-                    ],
-                    "type": "object",
-                    "additionalProperties": false,
-                    "required": [
-                        "path"
-                    ],
-                    "properties": {
-                        "name": {
-                            "description": "Title of the step to be shown in the CircleCI UI",
-                            "type": "string"
-                        },
-                        "path": {
-                            "description": "Directory in the primary container to save as job artifacts",
-                            "type": "string"
-                        },
-                        "destination": {
-                            "description": "Prefix added to the artifact paths in the artifacts API (default: the directory of the file specified in `path`)",
-                            "type": "string"
-                        }
-                    }
-                },
-                "store_test_results": {
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/builtinSteps/documentation/store_test_results"
-                        }
-                    ],
-                    "type": "object",
-                    "additionalProperties": false,
-                    "required": [
-                        "path"
-                    ],
-                    "properties": {
-                        "name": {
-                            "description": "Title of the step to be shown in the CircleCI UI",
-                            "type": "string"
-                        },
-                        "path": {
-                            "description": "Path (absolute, or relative to your `working_directory`) to directory containing subdirectories of JUnit XML or Cucumber JSON test metadata files",
-                            "type": "string"
-                        }
-                    }
-                },
-                "persist_to_workspace": {
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/builtinSteps/documentation/persist_to_workspace"
-                        }
-                    ],
-                    "type": "object",
-                    "additionalProperties": false,
-                    "required": [
-                        "root",
-                        "paths"
-                    ],
-                    "properties": {
-                        "name": {
-                            "description": "Title of the step to be shown in the CircleCI UI",
-                            "type": "string"
-                        },
-                        "root": {
-                            "description": "Either an absolute path or a path relative to `working_directory`",
-                            "type": "string"
-                        },
-                        "paths": {
-                            "description": "Glob identifying file(s), or a non-glob path to a directory to add to the shared workspace. Interpreted as relative to the workspace root. Must not be the workspace root itself.",
-                            "type": "array",
-                            "items": {
+                            },
+                            "key": {
+                                "description": "Unique identifier for this cache",
                                 "type": "string"
-                            }
-                        }
-                    }
-                },
-                "attach_workspace": {
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/builtinSteps/documentation/attach_workspace"
-                        }
-                    ],
-                    "type": "object",
-                    "additionalProperties": false,
-                    "required": [
-                        "at"
-                    ],
-                    "properties": {
-                        "name": {
-                            "description": "Title of the step to be shown in the CircleCI UI",
-                            "type": "string"
-                        },
-                        "at": {
-                            "description": "Directory to attach the workspace to",
-                            "type": "string"
-                        }
-                    }
-                },
-                "add_ssh_keys": {
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/builtinSteps/documentation/add_ssh_keys"
-                        }
-                    ],
-                    "type": "object",
-                    "additionalProperties": false,
-                    "properties": {
-                        "name": {
-                            "description": "Title of the step to be shown in the CircleCI UI",
-                            "type": "string"
-                        },
-                        "fingerprints": {
-                            "description": "Directory to attach the workspace to",
-                            "type": "array",
-                            "items": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "when": {
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/builtinSteps/documentation/when"
-                        }
-                    ],
-                    "type": "object",
-                    "additionalProperties": false,
-                    "properties": {
-                        "condition": {
-                            "$ref": "#/definitions/logical"
-                        },
-                        "steps": {
-                            "description": "A list of steps to be performed",
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/step"
+                            },
+                            "name": {
+                                "type": "string",
+                                "description": "Title of the step to be shown in the CircleCI UI (default: 'Saving Cache')"
+                            },
+                            "when": {
+                                "description": "Specify when to enable or disable the step. Takes the following values: `always`, `on_success`, `on_fail` (default: `on_success`)",
+                                "enum": [
+                                    "always",
+                                    "on_success",
+                                    "on_fail"
+                                ]
                             }
                         }
                     },
-                    "required": [
-                        "condition",
-                        "steps"
-                    ]
-                },
-                "unless": {
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/builtinSteps/documentation/unless"
-                        }
-                    ],
-                    "type": "object",
-                    "additionalProperties": false,
-                    "properties": {
-                        "condition": {
-                            "$ref": "#/definitions/logical"
-                        },
-                        "steps": {
-                            "description": "A list of steps to be performed",
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/step"
+                    "restore_cache": {
+                        "allOf": [
+                            {
+                                "$ref": "#/definitions/builtinSteps/documentation/restore_cache"
                             }
-                        }
-                    },
-                    "required": [
-                        "condition",
-                        "steps"
-                    ]
-                }
-            }
-        },
-        "step": {
-            "anyOf": [
-                {
-                    "$ref": "#/definitions/builtinSteps/documentation/checkout",
-                    "enum": [
-                        "checkout"
-                    ]
-                },
-                {
-                    "$ref": "#/definitions/builtinSteps/documentation/setup_remote_docker",
-                    "enum": [
-                        "setup_remote_docker"
-                    ]
-                },
-                {
-                    "$ref": "#/definitions/builtinSteps/documentation/add_ssh_keys",
-                    "enum": [
-                        "add_ssh_keys"
-                    ]
-                },
-                {
-                    "description": "https://circleci.com/docs/reusing-config#invoking-reusable-commands\n\nA custom command defined via the top level commands key",
-                    "type": "string",
-                    "pattern": "^[a-z][a-z0-9_-]+$"
-                },
-                {
-                    "description": "https://circleci.com/docs/using-orbs#commands\n\nA custom command defined via an orb.",
-                    "type": "string",
-                    "pattern": "^[a-z][a-z0-9_-]+/[a-z][a-z0-9_-]+$"
-                },
-                {
-                    "type": "object",
-                    "minProperties": 1,
-                    "maxProperties": 1,
-                    "properties": {
-                        "run": {
-                            "$ref": "#/definitions/builtinSteps/configuration/run"
-                        },
-                        "checkout": {
-                            "$ref": "#/definitions/builtinSteps/configuration/checkout"
-                        },
-                        "setup_remote_docker": {
-                            "$ref": "#/definitions/builtinSteps/configuration/setup_remote_docker"
-                        },
-                        "save_cache": {
-                            "$ref": "#/definitions/builtinSteps/configuration/save_cache"
-                        },
-                        "restore_cache": {
-                            "$ref": "#/definitions/builtinSteps/configuration/restore_cache"
-                        },
-                        "deploy": {
-                            "$ref": "#/definitions/builtinSteps/configuration/deploy"
-                        },
-                        "store_artifacts": {
-                            "$ref": "#/definitions/builtinSteps/configuration/store_artifacts"
-                        },
-                        "store_test_results": {
-                            "$ref": "#/definitions/builtinSteps/configuration/store_test_results"
-                        },
-                        "persist_to_workspace": {
-                            "$ref": "#/definitions/builtinSteps/configuration/persist_to_workspace"
-                        },
-                        "attach_workspace": {
-                            "$ref": "#/definitions/builtinSteps/configuration/attach_workspace"
-                        },
-                        "add_ssh_keys": {
-                            "$ref": "#/definitions/builtinSteps/configuration/add_ssh_keys"
-                        },
-                        "when": {
-                            "$ref": "#/definitions/builtinSteps/configuration/when"
-                        },
-                        "unless": {
-                            "$ref": "#/definitions/builtinSteps/configuration/unless"
-                        }
-                    },
-                    "patternProperties": {
-                        "^[a-z][a-z0-9_-]+$": {
-                            "description": "https://circleci.com/docs/reusing-config#invoking-reusable-commands\n\nA custom command defined via the top level commands key"
-                        },
-                        "^[a-z][a-z0-9_-]+/[a-z][a-z0-9_-]+$": {
-                            "description": "https://circleci.com/docs/using-orbs#commands\n\nA custom command defined via an orb."
-                        }
-                    }
-                }
-            ]
-        },
-        "jobRef": {
-            "description": "Run a job as part of this workflow",
-            "type": "object",
-            "additionalProperties": true,
-            "properties": {
-                "requires": {
-                    "description": "Jobs are run in parallel by default, so you must explicitly require any dependencies by their job name.",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "name": {
-                    "description": "The name key can be used to ensure build numbers are not appended when invoking the same job multiple times (e.g., sayhello-1, sayhello-2). The name assigned needs to be unique, otherwise numbers will still be appended to the job name",
-                    "type": "string"
-                },
-                "context": {
-                    "description": "Either a single context name, or a list of contexts. The default name is `org-global`",
-                    "oneOf": [
-                        {
-                            "type": "string"
-                        },
-                        {
-                            "type": "array",
-                            "items": {
-                                "type": "string"
-                            }
-                        }
-                    ],
-                    "default": "org-global"
-                },
-                "type": {
-                    "description": "A job defined under the `workflows:` section may specify a type but it can only be `approval`.\n`approval` jobs must be manually approved before downstream jobs may proceed.\nFor [other job types](https://circleci.com/docs/reference/configuration-reference/#job-type), they must be specified under the `jobs:` section. Please see the [`type` under `workflows:` docs](https://circleci.com/docs/reference/configuration-reference/#type) for more information.",
-                    "enum": [
-                        "approval"
-                    ]
-                },
-                "filters": {
-                    "description": "A map defining rules for execution on specific branches",
-                    "type": "object",
-                    "additionalProperties": false,
-                    "properties": {
-                        "branches": {
-                            "$ref": "#/definitions/filter"
-                        },
-                        "tags": {
-                            "$ref": "#/definitions/filter"
-                        }
-                    }
-                },
-                "matrix": {
-                    "description": "https://circleci.com/docs/configuration-reference#matrix-requires-version-21\n\nThe matrix stanza allows you to run a parameterized job multiple times with different arguments.",
-                    "type": "object",
-                    "additionalProperties": false,
-                    "required": [
-                        "parameters"
-                    ],
-                    "properties": {
-                        "parameters": {
-                            "description": "A map of parameter names to every value the job should be called with",
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "array"
-                            }
-                        },
-                        "exclude": {
-                            "description": "A list of argument maps that should be excluded from the matrix",
-                            "type": "array",
-                            "items": {
-                                "type": "object"
-                            }
-                        },
-                        "alias": {
-                            "description": "An alias for the matrix, usable from another job's requires stanza. Defaults to the name of the job being executed",
-                            "type": "string"
-                        }
-                    }
-                }
-            }
-        },
-        "jobs": {
-            "description": "Jobs are collections of steps. All of the steps in the job are executed in a single unit, either within a fresh container or VM.",
-            "type": "object",
-            "additionalProperties": {
-                "type": "object",
-                "oneOf": [
-                    {
-                        "$ref": "#/definitions/executorChoice"
-                    },
-                    {
-                        "type": "object",
-                        "required": [
-                            "executor"
                         ],
-                        "properties": {
-                            "executor": {
-                                "description": "The name of the executor to use (defined via the top level executors map).",
-                                "type": "string"
-                            }
-                        }
-                    },
-                    {
-                        "type": "object",
-                        "required": [
-                            "executor"
-                        ],
-                        "properties": {
-                            "executor": {
-                                "description": "Executor stanza to use for the job",
+                        "oneOf": [
+                            {
                                 "type": "object",
+                                "additionalProperties": false,
                                 "required": [
-                                    "name"
+                                    "key"
+                                ],
+                                "properties": {
+                                    "key": {
+                                        "type": "string",
+                                        "description": "Single cache key to restore"
+                                    },
+                                    "name": {
+                                        "type": "string",
+                                        "description": "Title of the step to be shown in the CircleCI UI (default: 'Restoring Cache')"
+                                    }
+                                }
+                            },
+                            {
+                                "type": "object",
+                                "additionalProperties": false,
+                                "required": [
+                                    "keys"
                                 ],
                                 "properties": {
                                     "name": {
-                                        "description": "The name of the executor to use (defined via the top level executors map).",
-                                        "type": "string"
+                                        "type": "string",
+                                        "description": "Title of the step to be shown in the CircleCI UI (default: 'Restoring Cache')"
+                                    },
+                                    "keys": {
+                                        "description": "List of cache keys to lookup for a cache to restore. Only first existing key will be restored.",
+                                        "type": "array",
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        ]
+                    },
+                    "deploy": {
+                        "allOf": [
+                            {
+                                "$ref": "#/definitions/builtinSteps/documentation/deploy"
+                            },
+                            {
+                                "$ref": "#/definitions/builtinSteps/configuration/run"
+                            }
+                        ]
+                    },
+                    "store_artifacts": {
+                        "allOf": [
+                            {
+                                "$ref": "#/definitions/builtinSteps/documentation/store_artifacts"
+                            }
+                        ],
+                        "type": "object",
+                        "additionalProperties": false,
+                        "required": [
+                            "path"
+                        ],
+                        "properties": {
+                            "name": {
+                                "description": "Title of the step to be shown in the CircleCI UI",
+                                "type": "string"
+                            },
+                            "path": {
+                                "description": "Directory in the primary container to save as job artifacts",
+                                "type": "string"
+                            },
+                            "destination": {
+                                "description": "Prefix added to the artifact paths in the artifacts API (default: the directory of the file specified in `path`)",
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "store_test_results": {
+                        "allOf": [
+                            {
+                                "$ref": "#/definitions/builtinSteps/documentation/store_test_results"
+                            }
+                        ],
+                        "type": "object",
+                        "additionalProperties": false,
+                        "required": [
+                            "path"
+                        ],
+                        "properties": {
+                            "name": {
+                                "description": "Title of the step to be shown in the CircleCI UI",
+                                "type": "string"
+                            },
+                            "path": {
+                                "description": "Path (absolute, or relative to your `working_directory`) to directory containing subdirectories of JUnit XML or Cucumber JSON test metadata files",
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "persist_to_workspace": {
+                        "allOf": [
+                            {
+                                "$ref": "#/definitions/builtinSteps/documentation/persist_to_workspace"
+                            }
+                        ],
+                        "type": "object",
+                        "additionalProperties": false,
+                        "required": [
+                            "root",
+                            "paths"
+                        ],
+                        "properties": {
+                            "name": {
+                                "description": "Title of the step to be shown in the CircleCI UI",
+                                "type": "string"
+                            },
+                            "root": {
+                                "description": "Either an absolute path or a path relative to `working_directory`",
+                                "type": "string"
+                            },
+                            "paths": {
+                                "description": "Glob identifying file(s), or a non-glob path to a directory to add to the shared workspace. Interpreted as relative to the workspace root. Must not be the workspace root itself.",
+                                "type": "array",
+                                "items": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    },
+                    "attach_workspace": {
+                        "allOf": [
+                            {
+                                "$ref": "#/definitions/builtinSteps/documentation/attach_workspace"
+                            }
+                        ],
+                        "type": "object",
+                        "additionalProperties": false,
+                        "required": [
+                            "at"
+                        ],
+                        "properties": {
+                            "name": {
+                                "description": "Title of the step to be shown in the CircleCI UI",
+                                "type": "string"
+                            },
+                            "at": {
+                                "description": "Directory to attach the workspace to",
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "add_ssh_keys": {
+                        "allOf": [
+                            {
+                                "$ref": "#/definitions/builtinSteps/documentation/add_ssh_keys"
+                            }
+                        ],
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "name": {
+                                "description": "Title of the step to be shown in the CircleCI UI",
+                                "type": "string"
+                            },
+                            "fingerprints": {
+                                "description": "Directory to attach the workspace to",
+                                "type": "array",
+                                "items": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    },
+                    "when": {
+                        "allOf": [
+                            {
+                                "$ref": "#/definitions/builtinSteps/documentation/when"
+                            }
+                        ],
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "condition": {
+                                "$ref": "#/definitions/logical"
+                            },
+                            "steps": {
+                                "description": "A list of steps to be performed",
+                                "type": "array",
+                                "items": {
+                                    "$ref": "#/definitions/step"
+                                }
+                            }
+                        },
+                        "required": [
+                            "condition",
+                            "steps"
+                        ]
+                    },
+                    "unless": {
+                        "allOf": [
+                            {
+                                "$ref": "#/definitions/builtinSteps/documentation/unless"
+                            }
+                        ],
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "condition": {
+                                "$ref": "#/definitions/logical"
+                            },
+                            "steps": {
+                                "description": "A list of steps to be performed",
+                                "type": "array",
+                                "items": {
+                                    "$ref": "#/definitions/step"
+                                }
+                            }
+                        },
+                        "required": [
+                            "condition",
+                            "steps"
+                        ]
+                    }
+                }
+            },
+            "step": {
+                "anyOf": [
+                    {
+                        "$ref": "#/definitions/builtinSteps/documentation/checkout",
+                        "enum": [
+                            "checkout"
+                        ]
+                    },
+                    {
+                        "$ref": "#/definitions/builtinSteps/documentation/setup_remote_docker",
+                        "enum": [
+                            "setup_remote_docker"
+                        ]
+                    },
+                    {
+                        "$ref": "#/definitions/builtinSteps/documentation/add_ssh_keys",
+                        "enum": [
+                            "add_ssh_keys"
+                        ]
+                    },
+                    {
+                        "description": "https://circleci.com/docs/reusing-config#invoking-reusable-commands\n\nA custom command defined via the top level commands key",
+                        "type": "string",
+                        "pattern": "^[a-z][a-z0-9_-]+$"
+                    },
+                    {
+                        "description": "https://circleci.com/docs/using-orbs#commands\n\nA custom command defined via an orb.",
+                        "type": "string",
+                        "pattern": "^[a-z][a-z0-9_-]+/[a-z][a-z0-9_-]+$"
+                    },
+                    {
+                        "type": "object",
+                        "minProperties": 1,
+                        "maxProperties": 1,
+                        "properties": {
+                            "run": {
+                                "$ref": "#/definitions/builtinSteps/configuration/run"
+                            },
+                            "checkout": {
+                                "$ref": "#/definitions/builtinSteps/configuration/checkout"
+                            },
+                            "setup_remote_docker": {
+                                "$ref": "#/definitions/builtinSteps/configuration/setup_remote_docker"
+                            },
+                            "save_cache": {
+                                "$ref": "#/definitions/builtinSteps/configuration/save_cache"
+                            },
+                            "restore_cache": {
+                                "$ref": "#/definitions/builtinSteps/configuration/restore_cache"
+                            },
+                            "deploy": {
+                                "$ref": "#/definitions/builtinSteps/configuration/deploy"
+                            },
+                            "store_artifacts": {
+                                "$ref": "#/definitions/builtinSteps/configuration/store_artifacts"
+                            },
+                            "store_test_results": {
+                                "$ref": "#/definitions/builtinSteps/configuration/store_test_results"
+                            },
+                            "persist_to_workspace": {
+                                "$ref": "#/definitions/builtinSteps/configuration/persist_to_workspace"
+                            },
+                            "attach_workspace": {
+                                "$ref": "#/definitions/builtinSteps/configuration/attach_workspace"
+                            },
+                            "add_ssh_keys": {
+                                "$ref": "#/definitions/builtinSteps/configuration/add_ssh_keys"
+                            },
+                            "when": {
+                                "$ref": "#/definitions/builtinSteps/configuration/when"
+                            },
+                            "unless": {
+                                "$ref": "#/definitions/builtinSteps/configuration/unless"
+                            }
+                        },
+                        "patternProperties": {
+                            "^[a-z][a-z0-9_-]+$": {
+                                "description": "https://circleci.com/docs/reusing-config#invoking-reusable-commands\n\nA custom command defined via the top level commands key"
+                            },
+                            "^[a-z][a-z0-9_-]+/[a-z][a-z0-9_-]+$": {
+                                "description": "https://circleci.com/docs/using-orbs#commands\n\nA custom command defined via an orb."
+                            }
+                        }
+                    }
+                ]
+            },
+            "jobRef": {
+                "description": "Run a job as part of this workflow",
+                "type": "object",
+                "additionalProperties": true,
+                "properties": {
+                    "requires": {
+                        "description": "Jobs are run in parallel by default, so you must explicitly require any dependencies by their job name.",
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "name": {
+                        "description": "The name key can be used to ensure build numbers are not appended when invoking the same job multiple times (e.g., sayhello-1, sayhello-2). The name assigned needs to be unique, otherwise numbers will still be appended to the job name",
+                        "type": "string"
+                    },
+                    "context": {
+                        "description": "Either a single context name, or a list of contexts. The default name is `org-global`",
+                        "oneOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "array",
+                                "items": {
+                                    "type": "string"
+                                }
+                            }
+                        ],
+                        "default": "org-global"
+                    },
+                    "type": {
+                        "description": "A job defined under the `workflows:` section may specify a type but it can only be `approval`.\n`approval` jobs must be manually approved before downstream jobs may proceed.\nFor [other job types](https://circleci.com/docs/reference/configuration-reference/#job-type), they must be specified under the `jobs:` section. Please see the [`type` under `workflows:` docs](https://circleci.com/docs/reference/configuration-reference/#type) for more information.",
+                        "enum": [
+                            "approval"
+                        ]
+                    },
+                    "filters": {
+                        "description": "A map defining rules for execution on specific branches",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "branches": {
+                                "$ref": "#/definitions/filter"
+                            },
+                            "tags": {
+                                "$ref": "#/definitions/filter"
+                            }
+                        }
+                    },
+                    "matrix": {
+                        "description": "https://circleci.com/docs/configuration-reference#matrix-requires-version-21\n\nThe matrix stanza allows you to run a parameterized job multiple times with different arguments.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "required": [
+                            "parameters"
+                        ],
+                        "properties": {
+                            "parameters": {
+                                "description": "A map of parameter names to every value the job should be called with",
+                                "type": "object",
+                                "additionalProperties": {
+                                    "type": "array"
+                                }
+                            },
+                            "exclude": {
+                                "description": "A list of argument maps that should be excluded from the matrix",
+                                "type": "array",
+                                "items": {
+                                    "type": "object"
+                                }
+                            },
+                            "alias": {
+                                "description": "An alias for the matrix, usable from another job's requires stanza. Defaults to the name of the job being executed",
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            },
+            "jobs": {
+                "description": "Jobs are collections of steps. All of the steps in the job are executed in a single unit, either within a fresh container or VM.",
+                "type": "object",
+                "additionalProperties": {
+                    "type": "object",
+                    "oneOf": [
+                        {
+                            "$ref": "#/definitions/executorChoice"
+                        },
+                        {
+                            "type": "object",
+                            "required": [
+                                "executor"
+                            ],
+                            "properties": {
+                                "executor": {
+                                    "description": "The name of the executor to use (defined via the top level executors map).",
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        {
+                            "type": "object",
+                            "required": [
+                                "executor"
+                            ],
+                            "properties": {
+                                "executor": {
+                                    "description": "Executor stanza to use for the job",
+                                    "type": "object",
+                                    "required": [
+                                        "name"
+                                    ],
+                                    "properties": {
+                                        "name": {
+                                            "description": "The name of the executor to use (defined via the top level executors map).",
+                                            "type": "string"
+                                        }
                                     }
                                 }
                             }
                         }
-                    }
-                ],
-                "required": [
-                    "steps"
-                ],
-                "properties": {
-                    "type": {
-                        "description": "[Job Types](https://circleci.com/docs/reference/configuration-reference/#job-type)\nSome examples are `build`, `approval`, `no-op`, `release`.",
-                        "type": "string"
-                    },
-                    "shell": {
-                        "description": "Shell to use for execution command in all steps. Can be overridden by shell in each step",
-                        "type": "string"
-                    },
-                    "steps": {
-                        "description": "A list of steps to be performed",
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/definitions/step"
-                        }
-                    },
-                    "working_directory": {
-                        "description": "In which directory to run the steps. (default: `~/project`. `project` is a literal string, not the name of the project.) You can also refer the directory with `$CIRCLE_WORKING_DIRECTORY` environment variable.",
-                        "type": "string",
-                        "default": "~/project"
-                    },
-                    "parallelism": {
-                        "description": "Number of parallel instances of this job to run (default: 1)",
-                        "default": 1,
-                        "oneOf": [
-                            {
-                                "type": "integer"
-                            },
-                            {
-                                "type": "string",
-                                "pattern": "^<<.+\\..+>>$"
-                            }
-                        ]
-                    },
-                    "environment": {
-                        "description": "A map of environment variable names and variables (NOTE: these will override any environment variables you set in the CircleCI web interface).",
-                        "type": "object",
-                        "additionalProperties": {
-                            "type": [
-                                "string",
-                                "number"
-                            ]
-                        }
-                    },
-                    "branches": {
-                        "description": "A map defining rules for whitelisting/blacklisting execution of specific branches for a single job that is **not** in a workflow (default: all whitelisted). See Workflows for configuring branch execution for jobs in a workflow.",
-                        "type": "object",
-                        "additionalProperties": {
+                    ],
+                    "required": [
+                        "steps"
+                    ],
+                    "properties": {
+                        "type": {
+                            "description": "[Job Types](https://circleci.com/docs/reference/configuration-reference/#job-type)\nSome examples are `build`, `approval`, `no-op`, `release`.",
                             "type": "string"
+                        },
+                        "shell": {
+                            "description": "Shell to use for execution command in all steps. Can be overridden by shell in each step",
+                            "type": "string"
+                        },
+                        "steps": {
+                            "description": "A list of steps to be performed",
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/step"
+                            }
+                        },
+                        "working_directory": {
+                            "description": "In which directory to run the steps. (default: `~/project`. `project` is a literal string, not the name of the project.) You can also refer the directory with `$CIRCLE_WORKING_DIRECTORY` environment variable.",
+                            "type": "string",
+                            "default": "~/project"
+                        },
+                        "parallelism": {
+                            "description": "Number of parallel instances of this job to run (default: 1)",
+                            "default": 1,
+                            "oneOf": [
+                                {
+                                    "type": "integer"
+                                },
+                                {
+                                    "type": "string",
+                                    "pattern": "^<<.+\\..+>>$"
+                                }
+                            ]
+                        },
+                        "environment": {
+                            "description": "A map of environment variable names and variables (NOTE: these will override any environment variables you set in the CircleCI web interface).",
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": [
+                                    "string",
+                                    "number"
+                                ]
+                            }
+                        },
+                        "branches": {
+                            "description": "A map defining rules for whitelisting/blacklisting execution of specific branches for a single job that is **not** in a workflow (default: all whitelisted). See Workflows for configuring branch execution for jobs in a workflow.",
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
                         }
                     }
                 }
             }
-        }
-    },
-    "id": "https://json.schemastore.org/circleciconfig.json",
-    "properties": {
-        "version": {
-            "description": "The version field is intended to be used in order to issue warnings for deprecation or breaking changes.",
-            "default": 2.1,
-            "enum": [
-                2,
-                2.1
-            ]
         },
-        "orbs": {
-            "$ref": "#/definitions/orbs"
-        },
-        "commands": {
-            "$ref": "#/definitions/commands"
-        },
-        "executors": {
-            "$ref": "#/definitions/executors"
-        },
-        "jobs": {
-            "$ref": "#/definitions/jobs"
-        },
-        "workflows": {
-            "description": "Used for orchestrating all jobs. Each workflow consists of the workflow name as a key and a map as a value",
-            "type": "object",
-            "properties": {
-                "version": {
-                    "description": "The Workflows `version` field is used to issue warnings for deprecation or breaking changes during v2 Beta. It is deprecated as of CircleCI v2.1",
-                    "enum": [
-                        2
-                    ]
-                }
+        "id": "https://json.schemastore.org/circleciconfig.json",
+        "properties": {
+            "version": {
+                "description": "The version field is intended to be used in order to issue warnings for deprecation or breaking changes.",
+                "default": 2.1,
+                "enum": [
+                    2,
+                    2.1
+                ]
             },
-            "additionalProperties": {
+            "orbs": {
+                "$ref": "#/definitions/orbs"
+            },
+            "commands": {
+                "$ref": "#/definitions/commands"
+            },
+            "executors": {
+                "$ref": "#/definitions/executors"
+            },
+            "jobs": {
+                "$ref": "#/definitions/jobs"
+            },
+            "workflows": {
+                "description": "Used for orchestrating all jobs. Each workflow consists of the workflow name as a key and a map as a value",
                 "type": "object",
-                "additionalProperties": false,
                 "properties": {
-                    "triggers": {
-                        "description": "Specifies which triggers will cause this workflow to be executed. Default behavior is to trigger the workflow when pushing to a branch.",
-                        "type": "array",
-                        "items": {
-                            "type": "object",
-                            "additionalProperties": false,
-                            "properties": {
-                                "schedule": {
-                                    "description": "A workflow may have a schedule indicating it runs at a certain time, for example a nightly build that runs every day at 12am UTC:",
-                                    "type": "object",
-                                    "properties": {
-                                        "cron": {
-                                            "description": "See the [crontab man page](http://pubs.opengroup.org/onlinepubs/7908799/xcu/crontab.html)",
-                                            "type": "string"
-                                        },
-                                        "filters": {
-                                            "description": "A map defining rules for execution on specific branches",
-                                            "type": "object",
-                                            "additionalProperties": false,
-                                            "properties": {
-                                                "branches": {
-                                                    "$ref": "#/definitions/filter"
+                    "version": {
+                        "description": "The Workflows `version` field is used to issue warnings for deprecation or breaking changes during v2 Beta. It is deprecated as of CircleCI v2.1",
+                        "enum": [
+                            2
+                        ]
+                    }
+                },
+                "additionalProperties": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                        "triggers": {
+                            "description": "Specifies which triggers will cause this workflow to be executed. Default behavior is to trigger the workflow when pushing to a branch.",
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "additionalProperties": false,
+                                "properties": {
+                                    "schedule": {
+                                        "description": "A workflow may have a schedule indicating it runs at a certain time, for example a nightly build that runs every day at 12am UTC:",
+                                        "type": "object",
+                                        "properties": {
+                                            "cron": {
+                                                "description": "See the [crontab man page](http://pubs.opengroup.org/onlinepubs/7908799/xcu/crontab.html)",
+                                                "type": "string"
+                                            },
+                                            "filters": {
+                                                "description": "A map defining rules for execution on specific branches",
+                                                "type": "object",
+                                                "additionalProperties": false,
+                                                "properties": {
+                                                    "branches": {
+                                                        "$ref": "#/definitions/filter"
+                                                    }
                                                 }
                                             }
                                         }
                                     }
                                 }
                             }
-                        }
-                    },
-                    "max_auto_reruns": {
-                        "description": "The maximum number of times a workflow will be automatically rerun if it fails",
-                        "type": "integer",
-                        "minimum": 1,
-                        "maximum": 5
-                    },
-                    "jobs": {
-                        "type": "array",
-                        "items": {
-                            "oneOf": [
-                                {
-                                    "type": "string"
-                                },
-                                {
-                                    "type": "object",
-                                    "additionalProperties": {
+                        },
+                        "max_auto_reruns": {
+                            "description": "The maximum number of times a workflow will be automatically rerun if it fails",
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 5
+                        },
+                        "jobs": {
+                            "type": "array",
+                            "items": {
+                                "oneOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
                                         "type": "object",
-                                        "$ref": "#/definitions/jobRef"
+                                        "additionalProperties": {
+                                            "type": "object",
+                                            "$ref": "#/definitions/jobRef"
+                                        }
                                     }
-                                }
-                            ]
+                                ]
+                            }
+                        },
+                        "when": {
+                            "description": "Specify when to run the workflow.",
+                            "$ref": "#/definitions/logical"
+                        },
+                        "unless": {
+                            "description": "Specify when *not* to run the workflow.",
+                            "$ref": "#/definitions/logical"
                         }
-                    },
-                    "when": {
-                        "description": "Specify when to run the workflow.",
-                        "$ref": "#/definitions/logical"
-                    },
-                    "unless": {
-                        "description": "Specify when *not* to run the workflow.",
-                        "$ref": "#/definitions/logical"
                     }
                 }
             }
-        }
-    },
-    "required": [
-        "version"
-    ],
-    "title": "JSON schema for CircleCI configuration files",
-    "type": "object"
+        },
+        "required": [
+            "version"
+        ],
+        "title": "JSON schema for CircleCI configuration files",
+        "type": "object"
+    }
 }

--- a/schema.json
+++ b/schema.json
@@ -1,7 +1,560 @@
 {
-    "$schema": "http://json-schema.org/draft-06/schema#",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "CircleCI Config",
     "definitions": {
+        "jobDefinition": {
+            "oneOf": [
+                {
+                    "type": "string",
+                    "description": "Job may be a string reference to another job"
+                },
+                {
+                    "type": "object",
+                    "description": "Job definition object",
+                    "properties": {
+                        "type": {
+                            "enum": [
+                                "build",
+                                "release",
+                                "lock",
+                                "unlock",
+                                "approval",
+                                "no-op"
+                            ],
+                            "description": "The job type. If not specified, defaults to build."
+                        }
+                    },
+                    "if": {
+                        "required": [
+                            "type"
+                        ],
+                        "properties": {
+                            "type": {
+                                "const": "release"
+                            }
+                        }
+                    },
+                    "then": {
+                        "description": "Release job.",
+                        "required": [
+                            "plan_name"
+                        ],
+                        "properties": {
+                            "plan_name": {
+                                "type": "string",
+                                "description": "Required plan name for release jobs."
+                            }
+                        },
+                        "additionalProperties": true
+                    },
+                    "else": {
+                        "if": {
+                            "required": [
+                                "type"
+                            ],
+                            "properties": {
+                                "type": {
+                                    "enum": [
+                                        "lock",
+                                        "unlock"
+                                    ]
+                                }
+                            }
+                        },
+                        "then": {
+                            "description": "A lock/unlock job",
+                            "required": [
+                                "key"
+                            ],
+                            "properties": {
+                                "key": {
+                                    "type": "string",
+                                    "description": "Required key for lock/unlock jobs."
+                                }
+                            },
+                            "additionalProperties": true
+                        },
+                        "else": {
+                            "if": {
+                                "required": [
+                                    "type"
+                                ],
+                                "properties": {
+                                    "type": {
+                                        "enum": [
+                                            "approval",
+                                            "no-op"
+                                        ]
+                                    }
+                                }
+                            },
+                            "then": {
+                                "description": "Approval/no-op jobs primarily act as workflow markers. Other keys like `steps:` are permitted but will be ignored in the final pipeline.",
+                                "additionalProperties": true
+                            },
+                            "else": {
+                                "if": {
+                                    "description": "Condition: The job must be of type 'build' or have no type specified.",
+                                    "anyOf": [
+                                        {
+                                            "not": {
+                                                "required": [
+                                                    "type"
+                                                ]
+                                            }
+                                        },
+                                        {
+                                            "required": [
+                                                "type"
+                                            ],
+                                            "properties": {
+                                                "type": {
+                                                    "const": "build"
+                                                }
+                                            }
+                                        }
+                                    ]
+                                },
+                                "then": {
+                                    "description": "Validation: The job must adhere to the structure of a build job.",
+                                    "properties": {
+                                        "description": {
+                                            "type": "string"
+                                        },
+                                        "type": {
+                                            "const": "build",
+                                            "description": "The job type. If not specified, defaults to build."
+                                        },
+                                        "parallelism": {
+                                            "description": "A integer or a parameter evaluating to a integer",
+                                            "anyOf": [
+                                                {
+                                                    "oneOf": [
+                                                        {
+                                                            "type": "string",
+                                                            "pattern": " *<< *parameters.([^ ]+) *>> *"
+                                                        },
+                                                        {
+                                                            "type": "string",
+                                                            "pattern": " *<< *pipeline.parameters.([^ ]+) *>> *"
+                                                        }
+                                                    ]
+                                                },
+                                                {
+                                                    "type": "integer"
+                                                }
+                                            ]
+                                        },
+                                        "macos": {
+                                            "type": "object",
+                                            "properties": {
+                                                "xcode": {
+                                                    "type": [
+                                                        "string",
+                                                        "number"
+                                                    ]
+                                                },
+                                                "resource_class": {
+                                                    "type": "string"
+                                                },
+                                                "shell": {
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "required": [
+                                                "xcode"
+                                            ],
+                                            "additionalProperties": false
+                                        },
+                                        "resource_class": {
+                                            "type": "string"
+                                        },
+                                        "docker": {
+                                            "type": "array",
+                                            "minItems": 1,
+                                            "items": {
+                                                "type": "object",
+                                                "properties": {
+                                                    "image": {
+                                                        "type": "string"
+                                                    },
+                                                    "name": {
+                                                        "type": "string"
+                                                    },
+                                                    "entrypoint": {
+                                                        "oneOf": [
+                                                            {
+                                                                "type": "string"
+                                                            },
+                                                            {
+                                                                "type": "array",
+                                                                "items": {
+                                                                    "type": "string"
+                                                                }
+                                                            }
+                                                        ]
+                                                    },
+                                                    "command": {
+                                                        "oneOf": [
+                                                            {
+                                                                "type": "string"
+                                                            },
+                                                            {
+                                                                "type": "array",
+                                                                "items": {
+                                                                    "type": "string"
+                                                                }
+                                                            }
+                                                        ]
+                                                    },
+                                                    "user": {
+                                                        "type": "string"
+                                                    },
+                                                    "environment": {
+                                                        "oneOf": [
+                                                            {
+                                                                "description": "Allow null to account for empty `environment:` declarations.",
+                                                                "type": [
+                                                                    "string",
+                                                                    "null"
+                                                                ]
+                                                            },
+                                                            {
+                                                                "description": "An array of strings in the form KEY=VALUE",
+                                                                "type": "array",
+                                                                "items": {
+                                                                    "$ref": "#/definitions/environment"
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "object",
+                                                                "description": "The value should be a string, but we allow null, boolean and numbers too. Examples: `FOO: true` and `BAR: 2` `BAZ:`",
+                                                                "additionalProperties": {
+                                                                    "type": [
+                                                                        "string",
+                                                                        "boolean",
+                                                                        "number",
+                                                                        "null"
+                                                                    ]
+                                                                }
+                                                            }
+                                                        ]
+                                                    },
+                                                    "aws_auth": {
+                                                        "oneOf": [
+                                                            {
+                                                                "type": "object",
+                                                                "properties": {
+                                                                    "aws_access_key_id": {
+                                                                        "type": "string"
+                                                                    },
+                                                                    "aws_secret_access_key": {
+                                                                        "type": "string"
+                                                                    }
+                                                                },
+                                                                "required": [
+                                                                    "aws_access_key_id",
+                                                                    "aws_secret_access_key"
+                                                                ],
+                                                                "additionalProperties": false
+                                                            },
+                                                            {
+                                                                "type": "object",
+                                                                "properties": {
+                                                                    "oidc_role_arn": {
+                                                                        "type": "string"
+                                                                    }
+                                                                },
+                                                                "required": [
+                                                                    "oidc_role_arn"
+                                                                ],
+                                                                "additionalProperties": false
+                                                            }
+                                                        ]
+                                                    },
+                                                    "auth": {
+                                                        "type": "object",
+                                                        "properties": {
+                                                            "username": {
+                                                                "type": "string"
+                                                            },
+                                                            "password": {
+                                                                "type": "string"
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "username",
+                                                            "password"
+                                                        ],
+                                                        "additionalProperties": false
+                                                    }
+                                                },
+                                                "required": [
+                                                    "image"
+                                                ],
+                                                "additionalProperties": false
+                                            }
+                                        },
+                                        "steps": {
+                                            "type": "array",
+                                            "items": {
+                                                "$ref": "#/definitions/step"
+                                            },
+                                            "minItems": 1
+                                        },
+                                        "working_directory": {
+                                            "type": "string"
+                                        },
+                                        "retention": {
+                                            "type": "object",
+                                            "properties": {
+                                                "caches": {
+                                                    "type": "string",
+                                                    "pattern": "^([1-9]|1[0-5])d$"
+                                                }
+                                            },
+                                            "additionalProperties": false
+                                        },
+                                        "circleci_ip_ranges": {
+                                            "type": "boolean"
+                                        },
+                                        "machine": {
+                                            "description": "Machine must be a boolean or a map",
+                                            "oneOf": [
+                                                {
+                                                    "description": "A boolean or a template parameter evaluating to a boolean",
+                                                    "anyOf": [
+                                                        {
+                                                            "type": "string",
+                                                            "pattern": " *<< *parameters.([^ ]+) *>> *"
+                                                        },
+                                                        {
+                                                            "type": "boolean"
+                                                        },
+                                                        {
+                                                            "type": "number"
+                                                        },
+                                                        {
+                                                            "type": "string"
+                                                        }
+                                                    ]
+                                                },
+                                                {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "enabled": {
+                                                            "description": "A boolean or a template parameter evaluating to a boolean",
+                                                            "anyOf": [
+                                                                {
+                                                                    "type": "string",
+                                                                    "pattern": " *<< *parameters.([^ ]+) *>> *"
+                                                                },
+                                                                {
+                                                                    "type": "boolean"
+                                                                },
+                                                                {
+                                                                    "type": "number"
+                                                                },
+                                                                {
+                                                                    "type": "string"
+                                                                }
+                                                            ]
+                                                        },
+                                                        "image": {
+                                                            "type": "string"
+                                                        },
+                                                        "docker_layer_caching": {
+                                                            "description": "A boolean or a template parameter evaluating to a boolean",
+                                                            "anyOf": [
+                                                                {
+                                                                    "type": "string",
+                                                                    "pattern": " *<< *parameters.([^ ]+) *>> *"
+                                                                },
+                                                                {
+                                                                    "type": "boolean"
+                                                                },
+                                                                {
+                                                                    "type": "number"
+                                                                },
+                                                                {
+                                                                    "type": "string"
+                                                                }
+                                                            ]
+                                                        },
+                                                        "resource_class": {
+                                                            "type": "string"
+                                                        },
+                                                        "shell": {
+                                                            "type": "string"
+                                                        }
+                                                    },
+                                                    "additionalProperties": false
+                                                }
+                                            ]
+                                        },
+                                        "environment": {
+                                            "oneOf": [
+                                                {
+                                                    "description": "Allow null to account for empty `environment:` declarations.",
+                                                    "type": [
+                                                        "string",
+                                                        "null"
+                                                    ]
+                                                },
+                                                {
+                                                    "description": "An array of strings in the form KEY=VALUE",
+                                                    "type": "array",
+                                                    "items": {
+                                                        "$ref": "#/definitions/environment"
+                                                    }
+                                                },
+                                                {
+                                                    "type": "object",
+                                                    "description": "The value should be a string, but we allow null, boolean and numbers too. Examples: `FOO: true` and `BAR: 2` `BAZ:`",
+                                                    "additionalProperties": {
+                                                        "type": [
+                                                            "string",
+                                                            "boolean",
+                                                            "number",
+                                                            "null"
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        "executor": {
+                                            "oneOf": [
+                                                {
+                                                    "type": "string",
+                                                    "description": "short executor invocation, name of executor"
+                                                },
+                                                {
+                                                    "type": "object",
+                                                    "description": "executor invocation with arguments, i.e. parameters",
+                                                    "minProperties": 1,
+                                                    "additionalProperties": true,
+                                                    "properties": {
+                                                        "name": {
+                                                            "type": "string"
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "name"
+                                                    ]
+                                                }
+                                            ]
+                                        },
+                                        "shell": {
+                                            "oneOf": [
+                                                {
+                                                    "type": "string"
+                                                },
+                                                {
+                                                    "type": "array",
+                                                    "items": {
+                                                        "type": "string"
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        "parameters": {
+                                            "description": "Parameters given to a job.",
+                                            "type": "object",
+                                            "additionalProperties": {
+                                                "type": "object",
+                                                "properties": {
+                                                    "type": {
+                                                        "type": "string",
+                                                        "enum": [
+                                                            "boolean",
+                                                            "string",
+                                                            "steps",
+                                                            "enum",
+                                                            "executor",
+                                                            "integer",
+                                                            "env_var_name"
+                                                        ]
+                                                    },
+                                                    "default": {
+                                                        "oneOf": [
+                                                            {
+                                                                "type": "string"
+                                                            },
+                                                            {
+                                                                "type": "boolean"
+                                                            },
+                                                            {
+                                                                "type": "integer"
+                                                            },
+                                                            {
+                                                                "type": "array",
+                                                                "items": {
+                                                                    "$ref": "#/definitions/step"
+                                                                }
+                                                            }
+                                                        ]
+                                                    },
+                                                    "description": {
+                                                        "type": "string"
+                                                    },
+                                                    "enum": {
+                                                        "type": "array",
+                                                        "items": {
+                                                            "type": "string"
+                                                        }
+                                                    }
+                                                },
+                                                "additionalProperties": false,
+                                                "required": [
+                                                    "type"
+                                                ]
+                                            },
+                                            "minProperties": 1
+                                        }
+                                    },
+                                    "required": [
+                                        "steps"
+                                    ],
+                                    "additionalProperties": false,
+                                    "anyOf": [
+                                        {
+                                            "description": "A job must have one of `docker`, `machine`, `macos` or `executor` (which can provide docker/machine/macos information).",
+                                            "type": "object",
+                                            "required": [
+                                                "executor"
+                                            ]
+                                        },
+                                        {
+                                            "oneOf": [
+                                                {
+                                                    "type": "object",
+                                                    "required": [
+                                                        "machine"
+                                                    ]
+                                                },
+                                                {
+                                                    "type": "object",
+                                                    "required": [
+                                                        "docker"
+                                                    ]
+                                                },
+                                                {
+                                                    "type": "object",
+                                                    "required": [
+                                                        "macos"
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                },
+                                "else": false
+                            }
+                        }
+                    }
+                }
+            ]
+        },
         "orb": {
             "oneOf": [
                 {
@@ -18,432 +571,7 @@
                                 "pattern": "^[A-Za-z][A-Za-z\\s\\d_-]*$"
                             },
                             "additionalProperties": {
-                                "oneOf": [
-                                    {
-                                        "title": "CircleCI Orb: Jobs",
-                                        "type": "object",
-                                        "properties": {
-                                            "description": {
-                                                "type": "string"
-                                            },
-                                            "parallelism": {
-                                                "description": "A integer or a parameter evaluating to a integer",
-                                                "anyOf": [
-                                                    {
-                                                        "oneOf": [
-                                                            {
-                                                                "type": "string",
-                                                                "pattern": " *<< *parameters.([^ ]+) *>> *"
-                                                            },
-                                                            {
-                                                                "type": "string",
-                                                                "pattern": " *<< *pipeline.parameters.([^ ]+) *>> *"
-                                                            }
-                                                        ]
-                                                    },
-                                                    {
-                                                        "type": "integer"
-                                                    }
-                                                ]
-                                            },
-                                            "macos": {
-                                                "type": "object",
-                                                "properties": {
-                                                    "xcode": {
-                                                        "type": [
-                                                            "string",
-                                                            "number"
-                                                        ]
-                                                    },
-                                                    "resource_class": {
-                                                        "type": "string"
-                                                    },
-                                                    "shell": {
-                                                        "type": "string"
-                                                    }
-                                                },
-                                                "required": [
-                                                    "xcode"
-                                                ],
-                                                "additionalProperties": false
-                                            },
-                                            "resource_class": {
-                                                "type": "string"
-                                            },
-                                            "docker": {
-                                                "type": "array",
-                                                "minItems": 1,
-                                                "items": {
-                                                    "type": "object",
-                                                    "properties": {
-                                                        "image": {
-                                                            "type": "string"
-                                                        },
-                                                        "name": {
-                                                            "type": "string"
-                                                        },
-                                                        "entrypoint": {
-                                                            "oneOf": [
-                                                                {
-                                                                    "type": "string"
-                                                                },
-                                                                {
-                                                                    "type": "array",
-                                                                    "items": {
-                                                                        "type": "string"
-                                                                    }
-                                                                }
-                                                            ]
-                                                        },
-                                                        "command": {
-                                                            "oneOf": [
-                                                                {
-                                                                    "type": "string"
-                                                                },
-                                                                {
-                                                                    "type": "array",
-                                                                    "items": {
-                                                                        "type": "string"
-                                                                    }
-                                                                }
-                                                            ]
-                                                        },
-                                                        "user": {
-                                                            "type": "string"
-                                                        },
-                                                        "environment": {
-                                                            "oneOf": [
-                                                                {
-                                                                    "description": "Allow null to account for empty `environment:` declarations.",
-                                                                    "type": [
-                                                                        "string",
-                                                                        "null"
-                                                                    ]
-                                                                },
-                                                                {
-                                                                    "description": "An array of strings in the form KEY=VALUE",
-                                                                    "type": "array",
-                                                                    "items": {
-                                                                        "$ref": "#/definitions/environment"
-                                                                    }
-                                                                },
-                                                                {
-                                                                    "type": "object",
-                                                                    "description": "The value should be a string, but we allow null, boolean and numbers too. Examples: `FOO: true` and `BAR: 2` `BAZ:`",
-                                                                    "additionalProperties": {
-                                                                        "type": [
-                                                                            "string",
-                                                                            "boolean",
-                                                                            "number",
-                                                                            "null"
-                                                                        ]
-                                                                    }
-                                                                }
-                                                            ]
-                                                        },
-                                                        "aws_auth": {
-                                                            "oneOf": [
-                                                                {
-                                                                    "type": "object",
-                                                                    "properties": {
-                                                                        "aws_access_key_id": {
-                                                                            "type": "string"
-                                                                        },
-                                                                        "aws_secret_access_key": {
-                                                                            "type": "string"
-                                                                        }
-                                                                    },
-                                                                    "required": [
-                                                                        "aws_access_key_id",
-                                                                        "aws_secret_access_key"
-                                                                    ],
-                                                                    "additionalProperties": false
-                                                                },
-                                                                {
-                                                                    "type": "object",
-                                                                    "properties": {
-                                                                        "oidc_role_arn": {
-                                                                            "type": "string"
-                                                                        }
-                                                                    },
-                                                                    "required": [
-                                                                        "oidc_role_arn"
-                                                                    ],
-                                                                    "additionalProperties": false
-                                                                }
-                                                            ]
-                                                        },
-                                                        "auth": {
-                                                            "type": "object",
-                                                            "properties": {
-                                                                "username": {
-                                                                    "type": "string"
-                                                                },
-                                                                "password": {
-                                                                    "type": "string"
-                                                                }
-                                                            },
-                                                            "required": [
-                                                                "username",
-                                                                "password"
-                                                            ],
-                                                            "additionalProperties": false
-                                                        }
-                                                    },
-                                                    "required": [
-                                                        "image"
-                                                    ],
-                                                    "additionalProperties": false
-                                                }
-                                            },
-                                            "steps": {
-                                                "type": "array",
-                                                "items": {
-                                                    "$ref": "#/definitions/step"
-                                                },
-                                                "minItems": 1
-                                            },
-                                            "working_directory": {
-                                                "type": "string"
-                                            },
-                                            "circleci_ip_ranges": {
-                                                "type": "boolean"
-                                            },
-                                            "machine": {
-                                                "description": "Machine must be a boolean or a map",
-                                                "oneOf": [
-                                                    {
-                                                        "description": "A boolean or a template parameter evaluating to a boolean",
-                                                        "anyOf": [
-                                                            {
-                                                                "type": "string",
-                                                                "pattern": " *<< *parameters.([^ ]+) *>> *"
-                                                            },
-                                                            {
-                                                                "type": "boolean"
-                                                            },
-                                                            {
-                                                                "type": "number"
-                                                            },
-                                                            {
-                                                                "type": "string"
-                                                            }
-                                                        ]
-                                                    },
-                                                    {
-                                                        "type": "object",
-                                                        "properties": {
-                                                            "enabled": {
-                                                                "description": "A boolean or a template parameter evaluating to a boolean",
-                                                                "anyOf": [
-                                                                    {
-                                                                        "type": "string",
-                                                                        "pattern": " *<< *parameters.([^ ]+) *>> *"
-                                                                    },
-                                                                    {
-                                                                        "type": "boolean"
-                                                                    },
-                                                                    {
-                                                                        "type": "number"
-                                                                    },
-                                                                    {
-                                                                        "type": "string"
-                                                                    }
-                                                                ]
-                                                            },
-                                                            "image": {
-                                                                "type": "string"
-                                                            },
-                                                            "docker_layer_caching": {
-                                                                "description": "A boolean or a template parameter evaluating to a boolean",
-                                                                "anyOf": [
-                                                                    {
-                                                                        "type": "string",
-                                                                        "pattern": " *<< *parameters.([^ ]+) *>> *"
-                                                                    },
-                                                                    {
-                                                                        "type": "boolean"
-                                                                    },
-                                                                    {
-                                                                        "type": "number"
-                                                                    },
-                                                                    {
-                                                                        "type": "string"
-                                                                    }
-                                                                ]
-                                                            },
-                                                            "resource_class": {
-                                                                "type": "string"
-                                                            },
-                                                            "shell": {
-                                                                "type": "string"
-                                                            }
-                                                        },
-                                                        "additionalProperties": false
-                                                    }
-                                                ]
-                                            },
-                                            "environment": {
-                                                "oneOf": [
-                                                    {
-                                                        "description": "Allow null to account for empty `environment:` declarations.",
-                                                        "type": [
-                                                            "string",
-                                                            "null"
-                                                        ]
-                                                    },
-                                                    {
-                                                        "description": "An array of strings in the form KEY=VALUE",
-                                                        "type": "array",
-                                                        "items": {
-                                                            "$ref": "#/definitions/environment"
-                                                        }
-                                                    },
-                                                    {
-                                                        "type": "object",
-                                                        "description": "The value should be a string, but we allow null, boolean and numbers too. Examples: `FOO: true` and `BAR: 2` `BAZ:`",
-                                                        "additionalProperties": {
-                                                            "type": [
-                                                                "string",
-                                                                "boolean",
-                                                                "number",
-                                                                "null"
-                                                            ]
-                                                        }
-                                                    }
-                                                ]
-                                            },
-                                            "executor": {
-                                                "oneOf": [
-                                                    {
-                                                        "type": "string",
-                                                        "description": "short executor invocation, name of executor"
-                                                    },
-                                                    {
-                                                        "type": "object",
-                                                        "description": "executor invocation with arguments, i.e. parameters",
-                                                        "minProperties": 1,
-                                                        "additionalProperties": true,
-                                                        "properties": {
-                                                            "name": {
-                                                                "type": "string"
-                                                            }
-                                                        },
-                                                        "required": [
-                                                            "name"
-                                                        ]
-                                                    }
-                                                ]
-                                            },
-                                            "shell": {
-                                                "oneOf": [
-                                                    {
-                                                        "type": "string"
-                                                    },
-                                                    {
-                                                        "type": "array",
-                                                        "items": {
-                                                            "type": "string"
-                                                        }
-                                                    }
-                                                ]
-                                            },
-                                            "parameters": {
-                                                "description": "Parameters given to a job.",
-                                                "type": "object",
-                                                "additionalProperties": {
-                                                    "type": "object",
-                                                    "properties": {
-                                                        "type": {
-                                                            "type": "string",
-                                                            "enum": [
-                                                                "boolean",
-                                                                "string",
-                                                                "steps",
-                                                                "enum",
-                                                                "executor",
-                                                                "integer",
-                                                                "env_var_name"
-                                                            ]
-                                                        },
-                                                        "default": {
-                                                            "oneOf": [
-                                                                {
-                                                                    "type": "string"
-                                                                },
-                                                                {
-                                                                    "type": "boolean"
-                                                                },
-                                                                {
-                                                                    "type": "integer"
-                                                                },
-                                                                {
-                                                                    "type": "array",
-                                                                    "items": {
-                                                                        "$ref": "#/definitions/step"
-                                                                    }
-                                                                }
-                                                            ]
-                                                        },
-                                                        "description": {
-                                                            "type": "string"
-                                                        },
-                                                        "enum": {
-                                                            "type": "array",
-                                                            "items": {
-                                                                "type": "string"
-                                                            }
-                                                        }
-                                                    },
-                                                    "additionalProperties": false,
-                                                    "required": [
-                                                        "type"
-                                                    ]
-                                                },
-                                                "minProperties": 1
-                                            }
-                                        },
-                                        "required": [
-                                            "steps"
-                                        ],
-                                        "additionalProperties": false,
-                                        "anyOf": [
-                                            {
-                                                "description": "A job must have one of `docker`, `machine`, `macos` or `executor` (which can provide docker/machine/macos information).",
-                                                "type": "object",
-                                                "required": [
-                                                    "executor"
-                                                ]
-                                            },
-                                            {
-                                                "oneOf": [
-                                                    {
-                                                        "type": "object",
-                                                        "required": [
-                                                            "machine"
-                                                        ]
-                                                    },
-                                                    {
-                                                        "type": "object",
-                                                        "required": [
-                                                            "docker"
-                                                        ]
-                                                    },
-                                                    {
-                                                        "type": "object",
-                                                        "required": [
-                                                            "macos"
-                                                        ]
-                                                    }
-                                                ]
-                                            }
-                                        ]
-                                    },
-                                    {
-                                        "type": "string",
-                                        "description": "Job may be a string reference to another job"
-                                    }
-                                ]
+                                "$ref": "#/definitions/jobDefinition"
                             }
                         },
                         "commands": {
@@ -1810,457 +1938,7 @@
                 "pattern": "^[A-Za-z][A-Za-z\\s\\d_-]*$"
             },
             "additionalProperties": {
-                "oneOf": [
-                    {
-                        "title": "CircleCI Orb: Jobs",
-                        "type": "object",
-                        "properties": {
-                            "description": {
-                                "type": "string"
-                            },
-                            "type": {
-                                "type": "string",
-                                "description": "The job type. Further validation is handled by the language server."
-                            },
-                            "parallelism": {
-                                "description": "A integer or a parameter evaluating to a integer",
-                                "anyOf": [
-                                    {
-                                        "oneOf": [
-                                            {
-                                                "type": "string",
-                                                "pattern": " *<< *parameters.([^ ]+) *>> *"
-                                            },
-                                            {
-                                                "type": "string",
-                                                "pattern": " *<< *pipeline.parameters.([^ ]+) *>> *"
-                                            }
-                                        ]
-                                    },
-                                    {
-                                        "type": "integer"
-                                    }
-                                ]
-                            },
-                            "macos": {
-                                "type": "object",
-                                "properties": {
-                                    "xcode": {
-                                        "type": [
-                                            "string",
-                                            "number"
-                                        ]
-                                    },
-                                    "resource_class": {
-                                        "type": "string"
-                                    },
-                                    "shell": {
-                                        "type": "string"
-                                    }
-                                },
-                                "required": [
-                                    "xcode"
-                                ],
-                                "additionalProperties": false
-                            },
-                            "resource_class": {
-                                "type": "string"
-                            },
-                            "docker": {
-                                "type": "array",
-                                "minItems": 1,
-                                "items": {
-                                    "type": "object",
-                                    "properties": {
-                                        "image": {
-                                            "type": "string"
-                                        },
-                                        "name": {
-                                            "type": "string"
-                                        },
-                                        "entrypoint": {
-                                            "oneOf": [
-                                                {
-                                                    "type": "string"
-                                                },
-                                                {
-                                                    "type": "array",
-                                                    "items": {
-                                                        "type": "string"
-                                                    }
-                                                }
-                                            ]
-                                        },
-                                        "command": {
-                                            "oneOf": [
-                                                {
-                                                    "type": "string"
-                                                },
-                                                {
-                                                    "type": "array",
-                                                    "items": {
-                                                        "type": "string"
-                                                    }
-                                                }
-                                            ]
-                                        },
-                                        "user": {
-                                            "type": "string"
-                                        },
-                                        "environment": {
-                                            "oneOf": [
-                                                {
-                                                    "description": "Allow null to account for empty `environment:` declarations.",
-                                                    "type": [
-                                                        "string",
-                                                        "null"
-                                                    ]
-                                                },
-                                                {
-                                                    "description": "An array of strings in the form KEY=VALUE",
-                                                    "type": "array",
-                                                    "items": {
-                                                        "$ref": "#/definitions/environment"
-                                                    }
-                                                },
-                                                {
-                                                    "type": "object",
-                                                    "description": "The value should be a string, but we allow null, boolean and numbers too. Examples: `FOO: true` and `BAR: 2` `BAZ:`",
-                                                    "additionalProperties": {
-                                                        "type": [
-                                                            "string",
-                                                            "boolean",
-                                                            "number",
-                                                            "null"
-                                                        ]
-                                                    }
-                                                }
-                                            ]
-                                        },
-                                        "aws_auth": {
-                                            "oneOf": [
-                                                {
-                                                    "type": "object",
-                                                    "properties": {
-                                                        "aws_access_key_id": {
-                                                            "type": "string"
-                                                        },
-                                                        "aws_secret_access_key": {
-                                                            "type": "string"
-                                                        }
-                                                    },
-                                                    "required": [
-                                                        "aws_access_key_id",
-                                                        "aws_secret_access_key"
-                                                    ],
-                                                    "additionalProperties": false
-                                                },
-                                                {
-                                                    "type": "object",
-                                                    "properties": {
-                                                        "oidc_role_arn": {
-                                                            "type": "string"
-                                                        }
-                                                    },
-                                                    "required": [
-                                                        "oidc_role_arn"
-                                                    ],
-                                                    "additionalProperties": false
-                                                }
-                                            ]
-                                        },
-                                        "auth": {
-                                            "type": "object",
-                                            "properties": {
-                                                "username": {
-                                                    "type": "string"
-                                                },
-                                                "password": {
-                                                    "type": "string"
-                                                }
-                                            },
-                                            "required": [
-                                                "username",
-                                                "password"
-                                            ],
-                                            "additionalProperties": false
-                                        }
-                                    },
-                                    "required": [
-                                        "image"
-                                    ],
-                                    "additionalProperties": false
-                                }
-                            },
-                            "steps": {
-                                "type": "array",
-                                "items": {
-                                    "$ref": "#/definitions/step"
-                                },
-                                "minItems": 1
-                            },
-                            "working_directory": {
-                                "type": "string"
-                            },
-                            "retention": {
-                                "type": "object",
-                                "properties": {
-                                    "caches": {
-                                        "type": "string",
-                                        "pattern": "^([1-9]|1[0-5])d$"
-                                    }
-                                },
-                                "additionalProperties": false
-                            },
-                            "circleci_ip_ranges": {
-                                "type": "boolean"
-                            },
-                            "machine": {
-                                "description": "Machine must be a boolean or a map",
-                                "oneOf": [
-                                    {
-                                        "description": "A boolean or a template parameter evaluating to a boolean",
-                                        "anyOf": [
-                                            {
-                                                "type": "string",
-                                                "pattern": " *<< *parameters.([^ ]+) *>> *"
-                                            },
-                                            {
-                                                "type": "boolean"
-                                            },
-                                            {
-                                                "type": "number"
-                                            },
-                                            {
-                                                "type": "string"
-                                            }
-                                        ]
-                                    },
-                                    {
-                                        "type": "object",
-                                        "properties": {
-                                            "enabled": {
-                                                "description": "A boolean or a template parameter evaluating to a boolean",
-                                                "anyOf": [
-                                                    {
-                                                        "type": "string",
-                                                        "pattern": " *<< *parameters.([^ ]+) *>> *"
-                                                    },
-                                                    {
-                                                        "type": "boolean"
-                                                    },
-                                                    {
-                                                        "type": "number"
-                                                    },
-                                                    {
-                                                        "type": "string"
-                                                    }
-                                                ]
-                                            },
-                                            "image": {
-                                                "type": "string"
-                                            },
-                                            "docker_layer_caching": {
-                                                "description": "A boolean or a template parameter evaluating to a boolean",
-                                                "anyOf": [
-                                                    {
-                                                        "type": "string",
-                                                        "pattern": " *<< *parameters.([^ ]+) *>> *"
-                                                    },
-                                                    {
-                                                        "type": "boolean"
-                                                    },
-                                                    {
-                                                        "type": "number"
-                                                    },
-                                                    {
-                                                        "type": "string"
-                                                    }
-                                                ]
-                                            },
-                                            "resource_class": {
-                                                "type": "string"
-                                            },
-                                            "shell": {
-                                                "type": "string"
-                                            }
-                                        },
-                                        "additionalProperties": false
-                                    }
-                                ]
-                            },
-                            "environment": {
-                                "oneOf": [
-                                    {
-                                        "description": "Allow null to account for empty `environment:` declarations.",
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ]
-                                    },
-                                    {
-                                        "description": "An array of strings in the form KEY=VALUE",
-                                        "type": "array",
-                                        "items": {
-                                            "$ref": "#/definitions/environment"
-                                        }
-                                    },
-                                    {
-                                        "type": "object",
-                                        "description": "The value should be a string, but we allow null, boolean and numbers too. Examples: `FOO: true` and `BAR: 2` `BAZ:`",
-                                        "additionalProperties": {
-                                            "type": [
-                                                "string",
-                                                "boolean",
-                                                "number",
-                                                "null"
-                                            ]
-                                        }
-                                    }
-                                ]
-                            },
-                            "executor": {
-                                "oneOf": [
-                                    {
-                                        "type": "string",
-                                        "description": "short executor invocation, name of executor"
-                                    },
-                                    {
-                                        "type": "object",
-                                        "description": "executor invocation with arguments, i.e. parameters",
-                                        "minProperties": 1,
-                                        "additionalProperties": true,
-                                        "properties": {
-                                            "name": {
-                                                "type": "string"
-                                            }
-                                        },
-                                        "required": [
-                                            "name"
-                                        ]
-                                    }
-                                ]
-                            },
-                            "shell": {
-                                "oneOf": [
-                                    {
-                                        "type": "string"
-                                    },
-                                    {
-                                        "type": "array",
-                                        "items": {
-                                            "type": "string"
-                                        }
-                                    }
-                                ]
-                            },
-                            "parameters": {
-                                "description": "Parameters given to a job.",
-                                "type": "object",
-                                "additionalProperties": {
-                                    "type": "object",
-                                    "properties": {
-                                        "type": {
-                                            "type": "string",
-                                            "enum": [
-                                                "boolean",
-                                                "string",
-                                                "steps",
-                                                "enum",
-                                                "executor",
-                                                "integer",
-                                                "env_var_name"
-                                            ]
-                                        },
-                                        "default": {
-                                            "oneOf": [
-                                                {
-                                                    "type": "string"
-                                                },
-                                                {
-                                                    "type": "boolean"
-                                                },
-                                                {
-                                                    "type": "integer"
-                                                },
-                                                {
-                                                    "type": "array",
-                                                    "items": {
-                                                        "$ref": "#/definitions/step"
-                                                    }
-                                                }
-                                            ]
-                                        },
-                                        "description": {
-                                            "type": "string"
-                                        },
-                                        "enum": {
-                                            "type": "array",
-                                            "items": {
-                                                "type": "string"
-                                            }
-                                        }
-                                    },
-                                    "additionalProperties": false,
-                                    "required": [
-                                        "type"
-                                    ]
-                                },
-                                "minProperties": 1
-                            }
-                        },
-                        "required": [
-                            "steps"
-                        ],
-                        "additionalProperties": false,
-                        "anyOf": [
-                            {
-                                "description": "A job must have one of `docker`, `machine`, `macos` or `executor` (which can provide docker/machine/macos information).",
-                                "type": "object",
-                                "required": [
-                                    "executor"
-                                ]
-                            },
-                            {
-                                "oneOf": [
-                                    {
-                                        "type": "object",
-                                        "required": [
-                                            "machine"
-                                        ]
-                                    },
-                                    {
-                                        "type": "object",
-                                        "required": [
-                                            "docker"
-                                        ]
-                                    },
-                                    {
-                                        "type": "object",
-                                        "required": [
-                                            "macos"
-                                        ]
-                                    }
-                                ]
-                            }
-                        ]
-                    },
-                    {
-                        "title": "Job with type explicitly specified. Some job types like approval or no-op don't require steps or executors defined to be valid, so this rule allows them to be omitted if type is specified.",
-                        "type": "object",
-                        "additionalProperties": false,
-                        "properties": {
-                            "type": {
-                                "type": "string",
-                                "description": "The job type. Further validation is handled by the language server."
-                            }
-                        }
-                    },
-                    {
-                        "type": "string",
-                        "description": "Job may be a string reference to another job"
-                    }
-                ]
+                "$ref": "#/definitions/jobDefinition"
             }
         },
         "orbs": {

--- a/schema.json
+++ b/schema.json
@@ -1,3170 +1,3339 @@
 {
-	"$schema": "http://json-schema.org/draft-06/schema#",
-	"title": "CircleCI Config",
-	"definitions": {
-		"orb": {
-			"oneOf": [
-				{
-					"type": "string"
-				},
-				{
-					"type": "object",
-					"properties": {
-						"jobs": {
-							"description": "Any string key is allowed as job name.",
-							"type": "object",
-							"propertyNames": {
-								"type": "string",
-								"pattern": "^[A-Za-z][A-Za-z\\s\\d_-]*$"
-							},
-							"additionalProperties": {
-								"oneOf": [
-									{
-										"title": "CircleCI Orb: Jobs",
-										"type": "object",
-										"properties": {
-											"description": {
-												"type": "string"
-											},
-											"parallelism": {
-												"description": "A integer or a parameter evaluating to a integer",
-												"anyOf": [
-													{
-														"oneOf": [
-															{
-																"type": "string",
-																"pattern": " *<< *parameters.([^ ]+) *>> *"
-															},
-															{
-																"type": "string",
-																"pattern": " *<< *pipeline.parameters.([^ ]+) *>> *"
-															}
-														]
-													},
-													{
-														"type": "integer"
-													}
-												]
-											},
-											"macos": {
-												"type": "object",
-												"properties": {
-													"xcode": {
-														"type": [
-															"string",
-															"number"
-														]
-													},
-													"resource_class": {
-														"type": "string"
-													},
-													"shell": {
-														"type": "string"
-													}
-												},
-												"required": ["xcode"],
-												"additionalProperties": false
-											},
-											"resource_class": {
-												"type": "string"
-											},
-											"docker": {
-												"type": "array",
-												"minItems": 1,
-												"items": {
-													"type": "object",
-													"properties": {
-														"image": {
-															"type": "string"
-														},
-														"name": {
-															"type": "string"
-														},
-														"entrypoint": {
-															"oneOf": [
-																{
-																	"type": "string"
-																},
-																{
-																	"type": "array",
-																	"items": {
-																		"type": "string"
-																	}
-																}
-															]
-														},
-														"command": {
-															"oneOf": [
-																{
-																	"type": "string"
-																},
-																{
-																	"type": "array",
-																	"items": {
-																		"type": "string"
-																	}
-																}
-															]
-														},
-														"user": {
-															"type": "string"
-														},
-														"environment": {
-															"oneOf": [
-																{
-																	"description": "Allow null to account for empty `environment:` declarations.",
-																	"type": [
-																		"string",
-																		"null"
-																	]
-																},
-																{
-																	"description": "An array of strings in the form KEY=VALUE",
-																	"type": "array",
-																	"items": {
-																		"$ref": "#/definitions/environment"
-																	}
-																},
-																{
-																	"type": "object",
-																	"description": "The value should be a string, but we allow null, boolean and numbers too. Examples: `FOO: true` and `BAR: 2` `BAZ:`",
-																	"additionalProperties": {
-																		"type": [
-																			"string",
-																			"boolean",
-																			"number",
-																			"null"
-																		]
-																	}
-																}
-															]
-														},
-														"aws_auth": {
-															"oneOf": [
-																{
-																	"type": "object",
-																	"properties": {
-																		"aws_access_key_id": {
-																			"type": "string"
-																		},
-																		"aws_secret_access_key": {
-																			"type": "string"
-																		}
-																	},
-																	"required": [
-																		"aws_access_key_id",
-																		"aws_secret_access_key"
-																	],
-																	"additionalProperties": false
-																},
-																{
-																	"type": "object",
-																	"properties": {
-																		"oidc_role_arn": {
-																			"type": "string"
-																		}
-																	},
-																	"required": [
-																		"oidc_role_arn"
-																	],
-																	"additionalProperties": false
-																}
-															]
-														},
-														"auth": {
-															"type": "object",
-															"properties": {
-																"username": {
-																	"type": "string"
-																},
-																"password": {
-																	"type": "string"
-																}
-															},
-															"required": [
-																"username",
-																"password"
-															],
-															"additionalProperties": false
-														}
-													},
-													"required": ["image"],
-													"additionalProperties": false
-												}
-											},
-											"steps": {
-												"type": "array",
-												"items": {
-													"$ref": "#/definitions/step"
-												},
-												"minItems": 1
-											},
-											"working_directory": {
-												"type": "string"
-											},
-											"circleci_ip_ranges": {
-												"type": "boolean"
-											},
-											"machine": {
-												"description": "Machine must be a boolean or a map",
-												"oneOf": [
-													{
-														"description": "A boolean or a template parameter evaluating to a boolean",
-														"anyOf": [
-															{
-																"type": "string",
-																"pattern": " *<< *parameters.([^ ]+) *>> *"
-															},
-															{
-																"type": "boolean"
-															},
-															{
-																"type": "number"
-															},
-															{
-																"type": "string"
-															}
-														]
-													},
-													{
-														"type": "object",
-														"properties": {
-															"enabled": {
-																"description": "A boolean or a template parameter evaluating to a boolean",
-																"anyOf": [
-																	{
-																		"type": "string",
-																		"pattern": " *<< *parameters.([^ ]+) *>> *"
-																	},
-																	{
-																		"type": "boolean"
-																	},
-																	{
-																		"type": "number"
-																	},
-																	{
-																		"type": "string"
-																	}
-																]
-															},
-															"image": {
-																"type": "string"
-															},
-															"docker_layer_caching": {
-																"description": "A boolean or a template parameter evaluating to a boolean",
-																"anyOf": [
-																	{
-																		"type": "string",
-																		"pattern": " *<< *parameters.([^ ]+) *>> *"
-																	},
-																	{
-																		"type": "boolean"
-																	},
-																	{
-																		"type": "number"
-																	},
-																	{
-																		"type": "string"
-																	}
-																]
-															},
-															"resource_class": {
-																"type": "string"
-															},
-															"shell": {
-																"type": "string"
-															}
-														},
-														"additionalProperties": false
-													}
-												]
-											},
-											"environment": {
-												"oneOf": [
-													{
-														"description": "Allow null to account for empty `environment:` declarations.",
-														"type": [
-															"string",
-															"null"
-														]
-													},
-													{
-														"description": "An array of strings in the form KEY=VALUE",
-														"type": "array",
-														"items": {
-															"$ref": "#/definitions/environment"
-														}
-													},
-													{
-														"type": "object",
-														"description": "The value should be a string, but we allow null, boolean and numbers too. Examples: `FOO: true` and `BAR: 2` `BAZ:`",
-														"additionalProperties": {
-															"type": [
-																"string",
-																"boolean",
-																"number",
-																"null"
-															]
-														}
-													}
-												]
-											},
-											"executor": {
-												"oneOf": [
-													{
-														"type": "string",
-														"description": "short executor invocation, name of executor"
-													},
-													{
-														"type": "object",
-														"description": "executor invocation with arguments, i.e. parameters",
-														"minProperties": 1,
-														"additionalProperties": true,
-														"properties": {
-															"name": {
-																"type": "string"
-															}
-														},
-														"required": ["name"]
-													}
-												]
-											},
-											"shell": {
-												"oneOf": [
-													{
-														"type": "string"
-													},
-													{
-														"type": "array",
-														"items": {
-															"type": "string"
-														}
-													}
-												]
-											},
-											"parameters": {
-												"description": "Parameters given to a job.",
-												"type": "object",
-												"additionalProperties": {
-													"type": "object",
-													"properties": {
-														"type": {
-															"type": "string",
-															"enum": [
-																"boolean",
-																"string",
-																"steps",
-																"enum",
-																"executor",
-																"integer",
-																"env_var_name"
-															]
-														},
-														"default": {
-															"oneOf": [
-																{
-																	"type": "string"
-																},
-																{
-																	"type": "boolean"
-																},
-																{
-																	"type": "integer"
-																},
-																{
-																	"type": "array",
-																	"items": {
-																		"$ref": "#/definitions/step"
-																	}
-																}
-															]
-														},
-														"description": {
-															"type": "string"
-														},
-														"enum": {
-															"type": "array",
-															"items": {
-																"type": "string"
-															}
-														}
-													},
-													"additionalProperties": false,
-													"required": ["type"]
-												},
-												"minProperties": 1
-											}
-										},
-										"required": ["steps"],
-										"additionalProperties": false,
-										"anyOf": [
-											{
-												"description": "A job must have one of `docker`, `machine`, `macos` or `executor` (which can provide docker/machine/macos information).",
-												"type": "object",
-												"required": ["executor"]
-											},
-											{
-												"oneOf": [
-													{
-														"type": "object",
-														"required": ["machine"]
-													},
-													{
-														"type": "object",
-														"required": ["docker"]
-													},
-													{
-														"type": "object",
-														"required": ["macos"]
-													}
-												]
-											}
-										]
-									},
-									{
-										"type": "string",
-										"description": "Job may be a string reference to another job"
-									}
-								]
-							}
-						},
-						"commands": {
-							"type": "object",
-							"propertyNames": {
-								"pattern": "^[a-z][a-z\\d_-]*$"
-							},
-							"additionalProperties": {
-								"oneOf": [
-									{
-										"type": "object",
-										"properties": {
-											"description": {
-												"type": "string"
-											},
-											"parameters": {
-												"description": "Parameters given to a step.",
-												"type": "object",
-												"additionalProperties": {
-													"type": "object",
-													"properties": {
-														"type": {
-															"type": "string",
-															"enum": [
-																"boolean",
-																"string",
-																"steps",
-																"enum",
-																"executor",
-																"integer",
-																"env_var_name"
-															]
-														},
-														"default": {
-															"oneOf": [
-																{
-																	"type": "string"
-																},
-																{
-																	"type": "boolean"
-																},
-																{
-																	"type": "integer"
-																},
-																{
-																	"type": "array",
-																	"items": {
-																		"$ref": "#/definitions/step"
-																	}
-																}
-															]
-														},
-														"description": {
-															"type": "string"
-														},
-														"enum": {
-															"type": "array",
-															"items": {
-																"type": "string"
-															}
-														}
-													},
-													"additionalProperties": false,
-													"required": ["type"]
-												},
-												"minProperties": 1
-											},
-											"steps": {
-												"type": "array",
-												"items": {
-													"$ref": "#/definitions/step"
-												},
-												"minItems": 1
-											}
-										},
-										"required": ["steps"],
-										"additionalProperties": false
-									},
-									{
-										"type": "string",
-										"description": "Command may be a string reference to another command"
-									}
-								]
-							}
-						},
-						"executors": {
-							"type": "object",
-							"propertyNames": {
-								"pattern": "^[a-z][a-z\\d_-]*$"
-							},
-							"additionalProperties": {
-								"oneOf": [
-									{
-										"type": "object",
-										"properties": {
-											"description": {
-												"type": "string"
-											},
-											"macos": {
-												"type": "object",
-												"properties": {
-													"xcode": {
-														"type": [
-															"string",
-															"number"
-														]
-													},
-													"resource_class": {
-														"type": "string"
-													},
-													"shell": {
-														"type": "string"
-													}
-												},
-												"required": ["xcode"],
-												"additionalProperties": false
-											},
-											"resource_class": {
-												"type": "string"
-											},
-											"docker": {
-												"type": "array",
-												"minItems": 1,
-												"items": {
-													"type": "object",
-													"properties": {
-														"image": {
-															"type": "string"
-														},
-														"name": {
-															"type": "string"
-														},
-														"entrypoint": {
-															"oneOf": [
-																{
-																	"type": "string"
-																},
-																{
-																	"type": "array",
-																	"items": {
-																		"type": "string"
-																	}
-																}
-															]
-														},
-														"command": {
-															"oneOf": [
-																{
-																	"type": "string"
-																},
-																{
-																	"type": "array",
-																	"items": {
-																		"type": "string"
-																	}
-																}
-															]
-														},
-														"user": {
-															"type": "string"
-														},
-														"environment": {
-															"oneOf": [
-																{
-																	"description": "Allow null to account for empty `environment:` declarations.",
-																	"type": [
-																		"string",
-																		"null"
-																	]
-																},
-																{
-																	"description": "An array of strings in the form KEY=VALUE",
-																	"type": "array",
-																	"items": {
-																		"$ref": "#/definitions/environment"
-																	}
-																},
-																{
-																	"type": "object",
-																	"description": "The value should be a string, but we allow null, boolean and numbers too. Examples: `FOO: true` and `BAR: 2` `BAZ:`",
-																	"additionalProperties": {
-																		"type": [
-																			"string",
-																			"boolean",
-																			"number",
-																			"null"
-																		]
-																	}
-																}
-															]
-														},
-														"aws_auth": {
-															"oneOf": [
-																{
-																	"type": "object",
-																	"properties": {
-																		"aws_access_key_id": {
-																			"type": "string"
-																		},
-																		"aws_secret_access_key": {
-																			"type": "string"
-																		}
-																	},
-																	"required": [
-																		"aws_access_key_id",
-																		"aws_secret_access_key"
-																	],
-																	"additionalProperties": false
-																},
-																{
-																	"type": "object",
-																	"properties": {
-																		"oidc_role_arn": {
-																			"type": "string"
-																		}
-																	},
-																	"required": [
-																		"oidc_role_arn"
-																	],
-																	"additionalProperties": false
-																}
-															]
-														},
-														"auth": {
-															"type": "object",
-															"properties": {
-																"username": {
-																	"type": "string"
-																},
-																"password": {
-																	"type": "string"
-																}
-															},
-															"required": [
-																"username",
-																"password"
-															],
-															"additionalProperties": false
-														}
-													},
-													"required": ["image"],
-													"additionalProperties": false
-												}
-											},
-											"working_directory": {
-												"type": "string"
-											},
-											"machine": {
-												"description": "Machine must be a boolean or a map",
-												"oneOf": [
-													{
-														"description": "A boolean or a template parameter evaluating to a boolean",
-														"anyOf": [
-															{
-																"type": "string",
-																"pattern": " *<< *parameters.([^ ]+) *>> *"
-															},
-															{
-																"type": "boolean"
-															},
-															{
-																"type": "number"
-															},
-															{
-																"type": "string"
-															}
-														]
-													},
-													{
-														"type": "object",
-														"properties": {
-															"enabled": {
-																"description": "A boolean or a template parameter evaluating to a boolean",
-																"anyOf": [
-																	{
-																		"type": "string",
-																		"pattern": " *<< *parameters.([^ ]+) *>> *"
-																	},
-																	{
-																		"type": "boolean"
-																	},
-																	{
-																		"type": "number"
-																	},
-																	{
-																		"type": "string"
-																	}
-																]
-															},
-															"image": {
-																"type": "string"
-															},
-															"docker_layer_caching": {
-																"description": "A boolean or a template parameter evaluating to a boolean",
-																"anyOf": [
-																	{
-																		"type": "string",
-																		"pattern": " *<< *parameters.([^ ]+) *>> *"
-																	},
-																	{
-																		"type": "boolean"
-																	},
-																	{
-																		"type": "number"
-																	},
-																	{
-																		"type": "string"
-																	}
-																]
-															},
-															"resource_class": {
-																"type": "string"
-															},
-															"shell": {
-																"type": "string"
-															}
-														},
-														"additionalProperties": false
-													}
-												]
-											},
-											"environment": {
-												"oneOf": [
-													{
-														"description": "Allow null to account for empty `environment:` declarations.",
-														"type": [
-															"string",
-															"null"
-														]
-													},
-													{
-														"description": "An array of strings in the form KEY=VALUE",
-														"type": "array",
-														"items": {
-															"$ref": "#/definitions/environment"
-														}
-													},
-													{
-														"type": "object",
-														"description": "The value should be a string, but we allow null, boolean and numbers too. Examples: `FOO: true` and `BAR: 2` `BAZ:`",
-														"additionalProperties": {
-															"type": [
-																"string",
-																"boolean",
-																"number",
-																"null"
-															]
-														}
-													}
-												]
-											},
-											"shell": {
-												"oneOf": [
-													{
-														"type": "string"
-													},
-													{
-														"type": "array",
-														"items": {
-															"type": "string"
-														}
-													}
-												]
-											},
-											"parameters": {
-												"description": "Parameters given to a job.",
-												"type": "object",
-												"additionalProperties": {
-													"type": "object",
-													"properties": {
-														"type": {
-															"type": "string",
-															"enum": [
-																"boolean",
-																"string",
-																"steps",
-																"enum",
-																"executor",
-																"integer",
-																"env_var_name"
-															]
-														},
-														"default": {
-															"oneOf": [
-																{
-																	"type": "string"
-																},
-																{
-																	"type": "boolean"
-																},
-																{
-																	"type": "integer"
-																},
-																{
-																	"type": "array",
-																	"items": {
-																		"$ref": "#/definitions/step"
-																	}
-																}
-															]
-														},
-														"description": {
-															"type": "string"
-														},
-														"enum": {
-															"type": "array",
-															"items": {
-																"type": "string"
-															}
-														}
-													},
-													"additionalProperties": false,
-													"required": ["type"]
-												},
-												"minProperties": 1
-											}
-										},
-										"additionalProperties": false
-									},
-									{
-										"type": "string",
-										"description": "Executor may be a string reference to another executor"
-									}
-								]
-							}
-						},
-						"orbs": {
-							"$ref": "#/properties/orbs"
-						}
-					}
-				}
-			]
-		},
-		"environment": {
-			"oneOf": [
-				{
-					"description": "Allow null to account for empty `environment:` declarations.",
-					"type": ["string", "null"]
-				},
-				{
-					"description": "An array of strings in the form KEY=VALUE",
-					"type": "array",
-					"items": {
-						"$ref": "#/definitions/environment"
-					}
-				},
-				{
-					"type": "object",
-					"description": "The value should be a string, but we allow null, boolean and numbers too. Examples: `FOO: true` and `BAR: 2` `BAZ:`",
-					"additionalProperties": {
-						"type": ["string", "boolean", "number", "null"]
-					}
-				}
-			]
-		},
-		"logic": {
-			"oneOf": [
-				{
-					"description": "A boolean or a pipeline parameter evaluating to a boolean",
-					"anyOf": [
-						{
-							"type": "string",
-							"pattern": " *<< *pipeline.parameters.([^ ]+) *>> *"
-						},
-						{
-							"type": "boolean"
-						},
-						{
-							"type": "number"
-						},
-						{
-							"type": "string"
-						}
-					]
-				},
-				{
-					"type": "object",
-					"description": "This is the object that represents the logical/comparison operators",
-					"minProperties": 1,
-					"maxProperties": 1,
-					"additionalProperties": false,
-					"properties": {
-						"and": {
-							"type": "array",
-							"items": {
-								"$ref": "#/definitions/logic"
-							},
-							"minItems": 1
-						},
-						"or": {
-							"type": "array",
-							"items": {
-								"$ref": "#/definitions/logic"
-							},
-							"minItems": 1
-						},
-						"not": {
-							"$ref": "#/definitions/logic"
-						},
-						"equal": {
-							"type": "array",
-							"items": {
-								"$ref": "#/definitions/logic"
-							},
-							"minItems": 1
-						},
-						"matches": {
-							"type": "object",
-							"additionalProperties": false,
-							"properties": {
-								"pattern": {
-									"type": "string"
-								},
-								"value": {
-									"type": "string"
-								}
-							},
-							"required": ["pattern", "value"]
-						}
-					}
-				},
-				{
-					"type": "object",
-					"description": "This is the object operand",
-					"propertyNames": {
-						"not": {
-							"pattern": "^(and|or|not|equal|matches)$"
-						}
-					}
-				}
-			]
-		},
-		"step": {
-			"oneOf": [
-				{
-					"type": "string",
-					"description": "Shorthand commands, like `checkout`"
-				},
-				{
-					"type": "object",
-					"description": "long form commands like `run:`",
-					"propertyNames": {
-						"pattern": "^[a-z][a-z\\d\/_-]*$",
-						"not": {
-							"pattern": "^(when|unless)$"
-						}
-					},
-					"minProperties": 1,
-					"maxProperties": 1,
-					"properties": {
-						"run": {
-							"oneOf": [
-								{
-									"type": "string"
-								},
-								{
-									"type": "object",
-									"properties": {
-										"command": {
-											"type": "string"
-										}
-									},
-									"required": ["command"]
-								}
-							]
-						}
-					},
-					"additionalProperties": {
-						"type": ["object", "string"]
-					}
-				},
-				{
-					"type": "object",
-					"description": "`when`/`unless` step",
-					"additionalProperties": false,
-					"minProperties": 1,
-					"maxProperties": 1,
-					"properties": {
-						"when": {
-							"type": "object",
-							"required": ["condition", "steps"],
-							"properties": {
-								"condition": {
-									"$ref": "#/definitions/logic"
-								},
-								"steps": {
-									"oneOf": [
-										{
-											"type": "array",
-											"items": {
-												"$ref": "#/definitions/step"
-											}
-										},
-										{
-											"$ref": "#/definitions/step"
-										}
-									]
-								}
-							}
-						},
-						"unless": {
-							"type": "object",
-							"required": ["condition", "steps"],
-							"properties": {
-								"condition": {
-									"$ref": "#/definitions/logic"
-								},
-								"steps": {
-									"oneOf": [
-										{
-											"type": "array",
-											"items": {
-												"$ref": "#/definitions/step"
-											}
-										},
-										{
-											"$ref": "#/definitions/step"
-										}
-									]
-								}
-							}
-						}
-					}
-				}
-			]
-		}
-	},
-	"type": "object",
-	"properties": {
-		"executors": {
-			"type": ["object", "null"],
-			"propertyNames": {
-				"pattern": "^[a-z][a-z\\d_-]*$"
-			},
-			"additionalProperties": {
-				"oneOf": [
-					{
-						"type": "object",
-						"properties": {
-							"description": {
-								"type": "string"
-							},
-							"macos": {
-								"type": "object",
-								"properties": {
-									"xcode": {
-										"type": ["string", "number"]
-									},
-									"resource_class": {
-										"type": "string"
-									},
-									"shell": {
-										"type": "string"
-									}
-								},
-								"required": ["xcode"],
-								"additionalProperties": false
-							},
-							"resource_class": {
-								"type": "string"
-							},
-							"docker": {
-								"type": "array",
-								"minItems": 1,
-								"items": {
-									"type": "object",
-									"properties": {
-										"image": {
-											"type": "string"
-										},
-										"name": {
-											"type": "string"
-										},
-										"entrypoint": {
-											"oneOf": [
-												{
-													"type": "string"
-												},
-												{
-													"type": "array",
-													"items": {
-														"type": "string"
-													}
-												}
-											]
-										},
-										"command": {
-											"oneOf": [
-												{
-													"type": "string"
-												},
-												{
-													"type": "array",
-													"items": {
-														"type": "string"
-													}
-												}
-											]
-										},
-										"user": {
-											"type": "string"
-										},
-										"environment": {
-											"oneOf": [
-												{
-													"description": "Allow null to account for empty `environment:` declarations.",
-													"type": ["string", "null"]
-												},
-												{
-													"description": "An array of strings in the form KEY=VALUE",
-													"type": "array",
-													"items": {
-														"$ref": "#/definitions/environment"
-													}
-												},
-												{
-													"type": "object",
-													"description": "The value should be a string, but we allow null, boolean and numbers too. Examples: `FOO: true` and `BAR: 2` `BAZ:`",
-													"additionalProperties": {
-														"type": [
-															"string",
-															"boolean",
-															"number",
-															"null"
-														]
-													}
-												}
-											]
-										},
-										"aws_auth": {
-											"oneOf": [
-												{
-													"type": "object",
-													"properties": {
-														"aws_access_key_id": {
-															"type": "string"
-														},
-														"aws_secret_access_key": {
-															"type": "string"
-														}
-													},
-													"required": [
-														"aws_access_key_id",
-														"aws_secret_access_key"
-													],
-													"additionalProperties": false
-												},
-												{
-													"type": "object",
-													"properties": {
-														"oidc_role_arn": {
-															"type": "string"
-														}
-													},
-													"required": [
-														"oidc_role_arn"
-													],
-													"additionalProperties": false
-												}
-											]
-										},
-										"auth": {
-											"type": "object",
-											"properties": {
-												"username": {
-													"type": "string"
-												},
-												"password": {
-													"type": "string"
-												}
-											},
-											"required": [
-												"username",
-												"password"
-											],
-											"additionalProperties": false
-										}
-									},
-									"required": ["image"],
-									"additionalProperties": false
-								}
-							},
-							"working_directory": {
-								"type": "string"
-							},
-							"machine": {
-								"description": "Machine must be a boolean or a map",
-								"oneOf": [
-									{
-										"description": "A boolean or a template parameter evaluating to a boolean",
-										"anyOf": [
-											{
-												"type": "string",
-												"pattern": " *<< *parameters.([^ ]+) *>> *"
-											},
-											{
-												"type": "boolean"
-											},
-											{
-												"type": "number"
-											},
-											{
-												"type": "string"
-											}
-										]
-									},
-									{
-										"type": "object",
-										"properties": {
-											"enabled": {
-												"description": "A boolean or a template parameter evaluating to a boolean",
-												"anyOf": [
-													{
-														"type": "string",
-														"pattern": " *<< *parameters.([^ ]+) *>> *"
-													},
-													{
-														"type": "boolean"
-													},
-													{
-														"type": "number"
-													},
-													{
-														"type": "string"
-													}
-												]
-											},
-											"image": {
-												"type": "string"
-											},
-											"docker_layer_caching": {
-												"description": "A boolean or a template parameter evaluating to a boolean",
-												"anyOf": [
-													{
-														"type": "string",
-														"pattern": " *<< *parameters.([^ ]+) *>> *"
-													},
-													{
-														"type": "boolean"
-													},
-													{
-														"type": "number"
-													},
-													{
-														"type": "string"
-													}
-												]
-											},
-											"resource_class": {
-												"type": "string"
-											},
-											"shell": {
-												"type": "string"
-											}
-										},
-										"additionalProperties": false
-									}
-								]
-							},
-							"environment": {
-								"oneOf": [
-									{
-										"description": "Allow null to account for empty `environment:` declarations.",
-										"type": ["string", "null"]
-									},
-									{
-										"description": "An array of strings in the form KEY=VALUE",
-										"type": "array",
-										"items": {
-											"$ref": "#/definitions/environment"
-										}
-									},
-									{
-										"type": "object",
-										"description": "The value should be a string, but we allow null, boolean and numbers too. Examples: `FOO: true` and `BAR: 2` `BAZ:`",
-										"additionalProperties": {
-											"type": [
-												"string",
-												"boolean",
-												"number",
-												"null"
-											]
-										}
-									}
-								]
-							},
-							"shell": {
-								"oneOf": [
-									{
-										"type": "string"
-									},
-									{
-										"type": "array",
-										"items": {
-											"type": "string"
-										}
-									}
-								]
-							},
-							"parameters": {
-								"description": "Parameters given to a job.",
-								"type": "object",
-								"additionalProperties": {
-									"type": "object",
-									"properties": {
-										"type": {
-											"type": "string",
-											"enum": [
-												"boolean",
-												"string",
-												"steps",
-												"enum",
-												"executor",
-												"integer",
-												"env_var_name"
-											]
-										},
-										"default": {
-											"oneOf": [
-												{
-													"type": "string"
-												},
-												{
-													"type": "boolean"
-												},
-												{
-													"type": "integer"
-												},
-												{
-													"type": "array",
-													"items": {
-														"$ref": "#/definitions/step"
-													}
-												}
-											]
-										},
-										"description": {
-											"type": "string"
-										},
-										"enum": {
-											"type": "array",
-											"items": {
-												"type": "string"
-											}
-										}
-									},
-									"additionalProperties": false,
-									"required": ["type"]
-								},
-								"minProperties": 1
-							}
-						},
-						"additionalProperties": false
-					},
-					{
-						"type": "string",
-						"description": "Executor may be a string reference to another executor"
-					}
-				]
-			}
-		},
-		"experimental": {
-			"type": "object",
-			"properties": {
-				"notify": {
-					"type": "object",
-					"properties": {
-						"branches": {
-							"type": "object",
-							"properties": {
-								"only": {
-									"oneOf": [
-										{
-											"type": "string"
-										},
-										{
-											"type": "array",
-											"items": {
-												"type": "string"
-											}
-										}
-									]
-								},
-								"ignore": {
-									"oneOf": [
-										{
-											"type": "string"
-										},
-										{
-											"type": "array",
-											"items": {
-												"type": "string"
-											}
-										}
-									]
-								}
-							},
-							"additionalProperties": false
-						}
-					},
-					"required": ["branches"],
-					"additionalProperties": false
-				}
-			},
-			"additionalProperties": false,
-			"required": ["notify"]
-		},
-		"workflows": {
-			"type": "object",
-			"properties": {
-				"version": {
-					"type": ["number", "string"]
-				}
-			},
-			"propertyNames": {
-				"pattern": ".+"
-			},
-			"additionalProperties": {
-				"type": "object",
-				"properties": {
-					"triggers": {
-						"type": "array",
-						"items": {
-							"type": "object",
-							"properties": {
-								"schedule": {
-									"type": "object",
-									"properties": {
-										"cron": {
-											"type": "string"
-										},
-										"filters": {
-											"type": "object",
-											"properties": {
-												"branches": {
-													"type": "object",
-													"properties": {
-														"only": {
-															"oneOf": [
-																{
-																	"type": "string"
-																},
-																{
-																	"type": "array",
-																	"items": {
-																		"type": "string"
-																	}
-																}
-															]
-														},
-														"ignore": {
-															"oneOf": [
-																{
-																	"type": "string"
-																},
-																{
-																	"type": "array",
-																	"items": {
-																		"type": "string"
-																	}
-																}
-															]
-														}
-													},
-													"additionalProperties": false
-												}
-											},
-											"additionalProperties": false
-										}
-									}
-								}
-							},
-							"additionalProperties": false
-						}
-					},
-          "max_auto_reruns": {
-            "type": "integer",
-            "minimum": 1,
-            "maximum": 5
-          },
-					"when": {
-						"$ref": "#/definitions/logic"
-					},
-					"unless": {
-						"$ref": "#/definitions/logic"
-					},
-					"jobs": {
-						"type": "array",
-						"minItems": 1,
-						"items": {
-							"oneOf": [
-								{
-									"type": "string"
-								},
-								{
-									"type": "object",
-									"maxProperties": 1,
-									"minProperties": 0,
-									"additionalProperties": {
-										"type": "object",
-										"properties": {
-											"requires": {
-												"type": "array",
-												"items": {
-													"oneOf": [
-                            {
-                              "type": "string"
+    "$schema": "http://json-schema.org/draft-06/schema#",
+    "title": "CircleCI Config",
+    "definitions": {
+        "orb": {
+            "oneOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "object",
+                    "properties": {
+                        "jobs": {
+                            "description": "Any string key is allowed as job name.",
+                            "type": "object",
+                            "propertyNames": {
+                                "type": "string",
+                                "pattern": "^[A-Za-z][A-Za-z\\s\\d_-]*$"
                             },
-                            {
-                              "type": "object",
-                              "minProperties": 1,
-                              "maxProperties": 1,
-                              "patternProperties": {
-                                "^[A-Za-z][A-Za-z\\s\\d_-]*$": {
-                                  "oneOf": [
+                            "additionalProperties": {
+                                "oneOf": [
                                     {
-                                      "type": "string",
-                                      "enum": ["success", "failed", "canceled"]
+                                        "title": "CircleCI Orb: Jobs",
+                                        "type": "object",
+                                        "properties": {
+                                            "description": {
+                                                "type": "string"
+                                            },
+                                            "parallelism": {
+                                                "description": "A integer or a parameter evaluating to a integer",
+                                                "anyOf": [
+                                                    {
+                                                        "oneOf": [
+                                                            {
+                                                                "type": "string",
+                                                                "pattern": " *<< *parameters.([^ ]+) *>> *"
+                                                            },
+                                                            {
+                                                                "type": "string",
+                                                                "pattern": " *<< *pipeline.parameters.([^ ]+) *>> *"
+                                                            }
+                                                        ]
+                                                    },
+                                                    {
+                                                        "type": "integer"
+                                                    }
+                                                ]
+                                            },
+                                            "macos": {
+                                                "type": "object",
+                                                "properties": {
+                                                    "xcode": {
+                                                        "type": [
+                                                            "string",
+                                                            "number"
+                                                        ]
+                                                    },
+                                                    "resource_class": {
+                                                        "type": "string"
+                                                    },
+                                                    "shell": {
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                "required": [
+                                                    "xcode"
+                                                ],
+                                                "additionalProperties": false
+                                            },
+                                            "resource_class": {
+                                                "type": "string"
+                                            },
+                                            "docker": {
+                                                "type": "array",
+                                                "minItems": 1,
+                                                "items": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "image": {
+                                                            "type": "string"
+                                                        },
+                                                        "name": {
+                                                            "type": "string"
+                                                        },
+                                                        "entrypoint": {
+                                                            "oneOf": [
+                                                                {
+                                                                    "type": "string"
+                                                                },
+                                                                {
+                                                                    "type": "array",
+                                                                    "items": {
+                                                                        "type": "string"
+                                                                    }
+                                                                }
+                                                            ]
+                                                        },
+                                                        "command": {
+                                                            "oneOf": [
+                                                                {
+                                                                    "type": "string"
+                                                                },
+                                                                {
+                                                                    "type": "array",
+                                                                    "items": {
+                                                                        "type": "string"
+                                                                    }
+                                                                }
+                                                            ]
+                                                        },
+                                                        "user": {
+                                                            "type": "string"
+                                                        },
+                                                        "environment": {
+                                                            "oneOf": [
+                                                                {
+                                                                    "description": "Allow null to account for empty `environment:` declarations.",
+                                                                    "type": [
+                                                                        "string",
+                                                                        "null"
+                                                                    ]
+                                                                },
+                                                                {
+                                                                    "description": "An array of strings in the form KEY=VALUE",
+                                                                    "type": "array",
+                                                                    "items": {
+                                                                        "$ref": "#/definitions/environment"
+                                                                    }
+                                                                },
+                                                                {
+                                                                    "type": "object",
+                                                                    "description": "The value should be a string, but we allow null, boolean and numbers too. Examples: `FOO: true` and `BAR: 2` `BAZ:`",
+                                                                    "additionalProperties": {
+                                                                        "type": [
+                                                                            "string",
+                                                                            "boolean",
+                                                                            "number",
+                                                                            "null"
+                                                                        ]
+                                                                    }
+                                                                }
+                                                            ]
+                                                        },
+                                                        "aws_auth": {
+                                                            "oneOf": [
+                                                                {
+                                                                    "type": "object",
+                                                                    "properties": {
+                                                                        "aws_access_key_id": {
+                                                                            "type": "string"
+                                                                        },
+                                                                        "aws_secret_access_key": {
+                                                                            "type": "string"
+                                                                        }
+                                                                    },
+                                                                    "required": [
+                                                                        "aws_access_key_id",
+                                                                        "aws_secret_access_key"
+                                                                    ],
+                                                                    "additionalProperties": false
+                                                                },
+                                                                {
+                                                                    "type": "object",
+                                                                    "properties": {
+                                                                        "oidc_role_arn": {
+                                                                            "type": "string"
+                                                                        }
+                                                                    },
+                                                                    "required": [
+                                                                        "oidc_role_arn"
+                                                                    ],
+                                                                    "additionalProperties": false
+                                                                }
+                                                            ]
+                                                        },
+                                                        "auth": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "username": {
+                                                                    "type": "string"
+                                                                },
+                                                                "password": {
+                                                                    "type": "string"
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "username",
+                                                                "password"
+                                                            ],
+                                                            "additionalProperties": false
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "image"
+                                                    ],
+                                                    "additionalProperties": false
+                                                }
+                                            },
+                                            "steps": {
+                                                "type": "array",
+                                                "items": {
+                                                    "$ref": "#/definitions/step"
+                                                },
+                                                "minItems": 1
+                                            },
+                                            "working_directory": {
+                                                "type": "string"
+                                            },
+                                            "circleci_ip_ranges": {
+                                                "type": "boolean"
+                                            },
+                                            "machine": {
+                                                "description": "Machine must be a boolean or a map",
+                                                "oneOf": [
+                                                    {
+                                                        "description": "A boolean or a template parameter evaluating to a boolean",
+                                                        "anyOf": [
+                                                            {
+                                                                "type": "string",
+                                                                "pattern": " *<< *parameters.([^ ]+) *>> *"
+                                                            },
+                                                            {
+                                                                "type": "boolean"
+                                                            },
+                                                            {
+                                                                "type": "number"
+                                                            },
+                                                            {
+                                                                "type": "string"
+                                                            }
+                                                        ]
+                                                    },
+                                                    {
+                                                        "type": "object",
+                                                        "properties": {
+                                                            "enabled": {
+                                                                "description": "A boolean or a template parameter evaluating to a boolean",
+                                                                "anyOf": [
+                                                                    {
+                                                                        "type": "string",
+                                                                        "pattern": " *<< *parameters.([^ ]+) *>> *"
+                                                                    },
+                                                                    {
+                                                                        "type": "boolean"
+                                                                    },
+                                                                    {
+                                                                        "type": "number"
+                                                                    },
+                                                                    {
+                                                                        "type": "string"
+                                                                    }
+                                                                ]
+                                                            },
+                                                            "image": {
+                                                                "type": "string"
+                                                            },
+                                                            "docker_layer_caching": {
+                                                                "description": "A boolean or a template parameter evaluating to a boolean",
+                                                                "anyOf": [
+                                                                    {
+                                                                        "type": "string",
+                                                                        "pattern": " *<< *parameters.([^ ]+) *>> *"
+                                                                    },
+                                                                    {
+                                                                        "type": "boolean"
+                                                                    },
+                                                                    {
+                                                                        "type": "number"
+                                                                    },
+                                                                    {
+                                                                        "type": "string"
+                                                                    }
+                                                                ]
+                                                            },
+                                                            "resource_class": {
+                                                                "type": "string"
+                                                            },
+                                                            "shell": {
+                                                                "type": "string"
+                                                            }
+                                                        },
+                                                        "additionalProperties": false
+                                                    }
+                                                ]
+                                            },
+                                            "environment": {
+                                                "oneOf": [
+                                                    {
+                                                        "description": "Allow null to account for empty `environment:` declarations.",
+                                                        "type": [
+                                                            "string",
+                                                            "null"
+                                                        ]
+                                                    },
+                                                    {
+                                                        "description": "An array of strings in the form KEY=VALUE",
+                                                        "type": "array",
+                                                        "items": {
+                                                            "$ref": "#/definitions/environment"
+                                                        }
+                                                    },
+                                                    {
+                                                        "type": "object",
+                                                        "description": "The value should be a string, but we allow null, boolean and numbers too. Examples: `FOO: true` and `BAR: 2` `BAZ:`",
+                                                        "additionalProperties": {
+                                                            "type": [
+                                                                "string",
+                                                                "boolean",
+                                                                "number",
+                                                                "null"
+                                                            ]
+                                                        }
+                                                    }
+                                                ]
+                                            },
+                                            "executor": {
+                                                "oneOf": [
+                                                    {
+                                                        "type": "string",
+                                                        "description": "short executor invocation, name of executor"
+                                                    },
+                                                    {
+                                                        "type": "object",
+                                                        "description": "executor invocation with arguments, i.e. parameters",
+                                                        "minProperties": 1,
+                                                        "additionalProperties": true,
+                                                        "properties": {
+                                                            "name": {
+                                                                "type": "string"
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "name"
+                                                        ]
+                                                    }
+                                                ]
+                                            },
+                                            "shell": {
+                                                "oneOf": [
+                                                    {
+                                                        "type": "string"
+                                                    },
+                                                    {
+                                                        "type": "array",
+                                                        "items": {
+                                                            "type": "string"
+                                                        }
+                                                    }
+                                                ]
+                                            },
+                                            "parameters": {
+                                                "description": "Parameters given to a job.",
+                                                "type": "object",
+                                                "additionalProperties": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "type": {
+                                                            "type": "string",
+                                                            "enum": [
+                                                                "boolean",
+                                                                "string",
+                                                                "steps",
+                                                                "enum",
+                                                                "executor",
+                                                                "integer",
+                                                                "env_var_name"
+                                                            ]
+                                                        },
+                                                        "default": {
+                                                            "oneOf": [
+                                                                {
+                                                                    "type": "string"
+                                                                },
+                                                                {
+                                                                    "type": "boolean"
+                                                                },
+                                                                {
+                                                                    "type": "integer"
+                                                                },
+                                                                {
+                                                                    "type": "array",
+                                                                    "items": {
+                                                                        "$ref": "#/definitions/step"
+                                                                    }
+                                                                }
+                                                            ]
+                                                        },
+                                                        "description": {
+                                                            "type": "string"
+                                                        },
+                                                        "enum": {
+                                                            "type": "array",
+                                                            "items": {
+                                                                "type": "string"
+                                                            }
+                                                        }
+                                                    },
+                                                    "additionalProperties": false,
+                                                    "required": [
+                                                        "type"
+                                                    ]
+                                                },
+                                                "minProperties": 1
+                                            }
+                                        },
+                                        "required": [
+                                            "steps"
+                                        ],
+                                        "additionalProperties": false,
+                                        "anyOf": [
+                                            {
+                                                "description": "A job must have one of `docker`, `machine`, `macos` or `executor` (which can provide docker/machine/macos information).",
+                                                "type": "object",
+                                                "required": [
+                                                    "executor"
+                                                ]
+                                            },
+                                            {
+                                                "oneOf": [
+                                                    {
+                                                        "type": "object",
+                                                        "required": [
+                                                            "machine"
+                                                        ]
+                                                    },
+                                                    {
+                                                        "type": "object",
+                                                        "required": [
+                                                            "docker"
+                                                        ]
+                                                    },
+                                                    {
+                                                        "type": "object",
+                                                        "required": [
+                                                            "macos"
+                                                        ]
+                                                    }
+                                                ]
+                                            }
+                                        ]
                                     },
                                     {
-                                      "type": "array",
-                                      "minLength": 1,
-                                      "items": {
                                         "type": "string",
-                                        "enum": ["success", "failed", "canceled"]
-                                      }
+                                        "description": "Job may be a string reference to another job"
                                     }
-                                  ]
-                                }}
+                                ]
                             }
-                          ]
-												}
-											},
-											"filters": {
-												"type": "object",
-												"description": "This is similar to to other `filters` in config, but has an additional key, `tags`",
-												"properties": {
-													"branches": {
-														"type": "object",
-														"properties": {
-															"only": {
-																"oneOf": [
-																	{
-																		"type": "string"
-																	},
-																	{
-																		"type": "array",
-																		"items": {
-																			"type": "string"
-																		}
-																	}
-																]
-															},
-															"ignore": {
-																"oneOf": [
-																	{
-																		"type": "string"
-																	},
-																	{
-																		"type": "array",
-																		"items": {
-																			"type": "string"
-																		}
-																	}
-																]
-															}
-														},
-														"additionalProperties": false
-													},
-													"tags": {
-														"type": "object",
-														"properties": {
-															"only": {
-																"oneOf": [
-																	{
-																		"type": "string"
-																	},
-																	{
-																		"type": "array",
-																		"items": {
-																			"type": "string"
-																		}
-																	}
-																]
-															},
-															"ignore": {
-																"oneOf": [
-																	{
-																		"type": "string"
-																	},
-																	{
-																		"type": "array",
-																		"items": {
-																			"type": "string"
-																		}
-																	}
-																]
-															}
-														},
-														"additionalProperties": false
-													}
-												},
-												"additionalProperties": false
-											},
-											"context": {
-												"oneOf": [
-													{
-														"type": "string"
-													},
-													{
-														"type": "array",
-														"items": {
-															"type": "string"
-														}
-													}
-												]
-											},
-											"type": {
-												"type": "string"
-											},
-											"pre-steps": {
-												"steps": {
-													"type": "array",
-													"items": {
-														"$ref": "#/definitions/step"
-													},
-													"minItems": 1
-												}
-											},
-											"post-steps": {
-												"steps": {
-													"type": "array",
-													"items": {
-														"$ref": "#/definitions/step"
-													},
-													"minItems": 1
-												}
-											},
-											"matrix": {
-												"type": "object",
-												"required": ["parameters"],
-												"properties": {
-													"parameters": {
-														"type": "object"
-													},
-													"exclude": {
-														"type": "array",
-														"items": {
-															"type": "object"
-														}
-													},
-													"alias": {
-														"type": "string"
-													}
-												}
-											},
-											"serial-group": {
-												"type": "string",
-												"minLength": 1
-											},
-                      "override-with": {
+                        },
+                        "commands": {
+                            "type": "object",
+                            "propertyNames": {
+                                "pattern": "^[a-z][a-z\\d_-]*$"
+                            },
+                            "additionalProperties": {
+                                "oneOf": [
+                                    {
+                                        "type": "object",
+                                        "properties": {
+                                            "description": {
+                                                "type": "string"
+                                            },
+                                            "parameters": {
+                                                "description": "Parameters given to a step.",
+                                                "type": "object",
+                                                "additionalProperties": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "type": {
+                                                            "type": "string",
+                                                            "enum": [
+                                                                "boolean",
+                                                                "string",
+                                                                "steps",
+                                                                "enum",
+                                                                "executor",
+                                                                "integer",
+                                                                "env_var_name"
+                                                            ]
+                                                        },
+                                                        "default": {
+                                                            "oneOf": [
+                                                                {
+                                                                    "type": "string"
+                                                                },
+                                                                {
+                                                                    "type": "boolean"
+                                                                },
+                                                                {
+                                                                    "type": "integer"
+                                                                },
+                                                                {
+                                                                    "type": "array",
+                                                                    "items": {
+                                                                        "$ref": "#/definitions/step"
+                                                                    }
+                                                                }
+                                                            ]
+                                                        },
+                                                        "description": {
+                                                            "type": "string"
+                                                        },
+                                                        "enum": {
+                                                            "type": "array",
+                                                            "items": {
+                                                                "type": "string"
+                                                            }
+                                                        }
+                                                    },
+                                                    "additionalProperties": false,
+                                                    "required": [
+                                                        "type"
+                                                    ]
+                                                },
+                                                "minProperties": 1
+                                            },
+                                            "steps": {
+                                                "type": "array",
+                                                "items": {
+                                                    "$ref": "#/definitions/step"
+                                                },
+                                                "minItems": 1
+                                            }
+                                        },
+                                        "required": [
+                                            "steps"
+                                        ],
+                                        "additionalProperties": false
+                                    },
+                                    {
+                                        "type": "string",
+                                        "description": "Command may be a string reference to another command"
+                                    }
+                                ]
+                            }
+                        },
+                        "executors": {
+                            "type": "object",
+                            "propertyNames": {
+                                "pattern": "^[a-z][a-z\\d_-]*$"
+                            },
+                            "additionalProperties": {
+                                "oneOf": [
+                                    {
+                                        "type": "object",
+                                        "properties": {
+                                            "description": {
+                                                "type": "string"
+                                            },
+                                            "macos": {
+                                                "type": "object",
+                                                "properties": {
+                                                    "xcode": {
+                                                        "type": [
+                                                            "string",
+                                                            "number"
+                                                        ]
+                                                    },
+                                                    "resource_class": {
+                                                        "type": "string"
+                                                    },
+                                                    "shell": {
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                "required": [
+                                                    "xcode"
+                                                ],
+                                                "additionalProperties": false
+                                            },
+                                            "resource_class": {
+                                                "type": "string"
+                                            },
+                                            "docker": {
+                                                "type": "array",
+                                                "minItems": 1,
+                                                "items": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "image": {
+                                                            "type": "string"
+                                                        },
+                                                        "name": {
+                                                            "type": "string"
+                                                        },
+                                                        "entrypoint": {
+                                                            "oneOf": [
+                                                                {
+                                                                    "type": "string"
+                                                                },
+                                                                {
+                                                                    "type": "array",
+                                                                    "items": {
+                                                                        "type": "string"
+                                                                    }
+                                                                }
+                                                            ]
+                                                        },
+                                                        "command": {
+                                                            "oneOf": [
+                                                                {
+                                                                    "type": "string"
+                                                                },
+                                                                {
+                                                                    "type": "array",
+                                                                    "items": {
+                                                                        "type": "string"
+                                                                    }
+                                                                }
+                                                            ]
+                                                        },
+                                                        "user": {
+                                                            "type": "string"
+                                                        },
+                                                        "environment": {
+                                                            "oneOf": [
+                                                                {
+                                                                    "description": "Allow null to account for empty `environment:` declarations.",
+                                                                    "type": [
+                                                                        "string",
+                                                                        "null"
+                                                                    ]
+                                                                },
+                                                                {
+                                                                    "description": "An array of strings in the form KEY=VALUE",
+                                                                    "type": "array",
+                                                                    "items": {
+                                                                        "$ref": "#/definitions/environment"
+                                                                    }
+                                                                },
+                                                                {
+                                                                    "type": "object",
+                                                                    "description": "The value should be a string, but we allow null, boolean and numbers too. Examples: `FOO: true` and `BAR: 2` `BAZ:`",
+                                                                    "additionalProperties": {
+                                                                        "type": [
+                                                                            "string",
+                                                                            "boolean",
+                                                                            "number",
+                                                                            "null"
+                                                                        ]
+                                                                    }
+                                                                }
+                                                            ]
+                                                        },
+                                                        "aws_auth": {
+                                                            "oneOf": [
+                                                                {
+                                                                    "type": "object",
+                                                                    "properties": {
+                                                                        "aws_access_key_id": {
+                                                                            "type": "string"
+                                                                        },
+                                                                        "aws_secret_access_key": {
+                                                                            "type": "string"
+                                                                        }
+                                                                    },
+                                                                    "required": [
+                                                                        "aws_access_key_id",
+                                                                        "aws_secret_access_key"
+                                                                    ],
+                                                                    "additionalProperties": false
+                                                                },
+                                                                {
+                                                                    "type": "object",
+                                                                    "properties": {
+                                                                        "oidc_role_arn": {
+                                                                            "type": "string"
+                                                                        }
+                                                                    },
+                                                                    "required": [
+                                                                        "oidc_role_arn"
+                                                                    ],
+                                                                    "additionalProperties": false
+                                                                }
+                                                            ]
+                                                        },
+                                                        "auth": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "username": {
+                                                                    "type": "string"
+                                                                },
+                                                                "password": {
+                                                                    "type": "string"
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "username",
+                                                                "password"
+                                                            ],
+                                                            "additionalProperties": false
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "image"
+                                                    ],
+                                                    "additionalProperties": false
+                                                }
+                                            },
+                                            "working_directory": {
+                                                "type": "string"
+                                            },
+                                            "machine": {
+                                                "description": "Machine must be a boolean or a map",
+                                                "oneOf": [
+                                                    {
+                                                        "description": "A boolean or a template parameter evaluating to a boolean",
+                                                        "anyOf": [
+                                                            {
+                                                                "type": "string",
+                                                                "pattern": " *<< *parameters.([^ ]+) *>> *"
+                                                            },
+                                                            {
+                                                                "type": "boolean"
+                                                            },
+                                                            {
+                                                                "type": "number"
+                                                            },
+                                                            {
+                                                                "type": "string"
+                                                            }
+                                                        ]
+                                                    },
+                                                    {
+                                                        "type": "object",
+                                                        "properties": {
+                                                            "enabled": {
+                                                                "description": "A boolean or a template parameter evaluating to a boolean",
+                                                                "anyOf": [
+                                                                    {
+                                                                        "type": "string",
+                                                                        "pattern": " *<< *parameters.([^ ]+) *>> *"
+                                                                    },
+                                                                    {
+                                                                        "type": "boolean"
+                                                                    },
+                                                                    {
+                                                                        "type": "number"
+                                                                    },
+                                                                    {
+                                                                        "type": "string"
+                                                                    }
+                                                                ]
+                                                            },
+                                                            "image": {
+                                                                "type": "string"
+                                                            },
+                                                            "docker_layer_caching": {
+                                                                "description": "A boolean or a template parameter evaluating to a boolean",
+                                                                "anyOf": [
+                                                                    {
+                                                                        "type": "string",
+                                                                        "pattern": " *<< *parameters.([^ ]+) *>> *"
+                                                                    },
+                                                                    {
+                                                                        "type": "boolean"
+                                                                    },
+                                                                    {
+                                                                        "type": "number"
+                                                                    },
+                                                                    {
+                                                                        "type": "string"
+                                                                    }
+                                                                ]
+                                                            },
+                                                            "resource_class": {
+                                                                "type": "string"
+                                                            },
+                                                            "shell": {
+                                                                "type": "string"
+                                                            }
+                                                        },
+                                                        "additionalProperties": false
+                                                    }
+                                                ]
+                                            },
+                                            "environment": {
+                                                "oneOf": [
+                                                    {
+                                                        "description": "Allow null to account for empty `environment:` declarations.",
+                                                        "type": [
+                                                            "string",
+                                                            "null"
+                                                        ]
+                                                    },
+                                                    {
+                                                        "description": "An array of strings in the form KEY=VALUE",
+                                                        "type": "array",
+                                                        "items": {
+                                                            "$ref": "#/definitions/environment"
+                                                        }
+                                                    },
+                                                    {
+                                                        "type": "object",
+                                                        "description": "The value should be a string, but we allow null, boolean and numbers too. Examples: `FOO: true` and `BAR: 2` `BAZ:`",
+                                                        "additionalProperties": {
+                                                            "type": [
+                                                                "string",
+                                                                "boolean",
+                                                                "number",
+                                                                "null"
+                                                            ]
+                                                        }
+                                                    }
+                                                ]
+                                            },
+                                            "shell": {
+                                                "oneOf": [
+                                                    {
+                                                        "type": "string"
+                                                    },
+                                                    {
+                                                        "type": "array",
+                                                        "items": {
+                                                            "type": "string"
+                                                        }
+                                                    }
+                                                ]
+                                            },
+                                            "parameters": {
+                                                "description": "Parameters given to a job.",
+                                                "type": "object",
+                                                "additionalProperties": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "type": {
+                                                            "type": "string",
+                                                            "enum": [
+                                                                "boolean",
+                                                                "string",
+                                                                "steps",
+                                                                "enum",
+                                                                "executor",
+                                                                "integer",
+                                                                "env_var_name"
+                                                            ]
+                                                        },
+                                                        "default": {
+                                                            "oneOf": [
+                                                                {
+                                                                    "type": "string"
+                                                                },
+                                                                {
+                                                                    "type": "boolean"
+                                                                },
+                                                                {
+                                                                    "type": "integer"
+                                                                },
+                                                                {
+                                                                    "type": "array",
+                                                                    "items": {
+                                                                        "$ref": "#/definitions/step"
+                                                                    }
+                                                                }
+                                                            ]
+                                                        },
+                                                        "description": {
+                                                            "type": "string"
+                                                        },
+                                                        "enum": {
+                                                            "type": "array",
+                                                            "items": {
+                                                                "type": "string"
+                                                            }
+                                                        }
+                                                    },
+                                                    "additionalProperties": false,
+                                                    "required": [
+                                                        "type"
+                                                    ]
+                                                },
+                                                "minProperties": 1
+                                            }
+                                        },
+                                        "additionalProperties": false
+                                    },
+                                    {
+                                        "type": "string",
+                                        "description": "Executor may be a string reference to another executor"
+                                    }
+                                ]
+                            }
+                        },
+                        "orbs": {
+                            "$ref": "#/properties/orbs"
+                        }
+                    }
+                }
+            ]
+        },
+        "environment": {
+            "oneOf": [
+                {
+                    "description": "Allow null to account for empty `environment:` declarations.",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                {
+                    "description": "An array of strings in the form KEY=VALUE",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/environment"
+                    }
+                },
+                {
+                    "type": "object",
+                    "description": "The value should be a string, but we allow null, boolean and numbers too. Examples: `FOO: true` and `BAR: 2` `BAZ:`",
+                    "additionalProperties": {
+                        "type": [
+                            "string",
+                            "boolean",
+                            "number",
+                            "null"
+                        ]
+                    }
+                }
+            ]
+        },
+        "logic": {
+            "oneOf": [
+                {
+                    "description": "A boolean or a pipeline parameter evaluating to a boolean",
+                    "anyOf": [
+                        {
+                            "type": "string",
+                            "pattern": " *<< *pipeline.parameters.([^ ]+) *>> *"
+                        },
+                        {
+                            "type": "boolean"
+                        },
+                        {
+                            "type": "number"
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ]
+                },
+                {
+                    "type": "object",
+                    "description": "This is the object that represents the logical/comparison operators",
+                    "minProperties": 1,
+                    "maxProperties": 1,
+                    "additionalProperties": false,
+                    "properties": {
+                        "and": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/logic"
+                            },
+                            "minItems": 1
+                        },
+                        "or": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/logic"
+                            },
+                            "minItems": 1
+                        },
+                        "not": {
+                            "$ref": "#/definitions/logic"
+                        },
+                        "equal": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/logic"
+                            },
+                            "minItems": 1
+                        },
+                        "matches": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                                "pattern": {
+                                    "type": "string"
+                                },
+                                "value": {
+                                    "type": "string"
+                                }
+                            },
+                            "required": [
+                                "pattern",
+                                "value"
+                            ]
+                        }
+                    }
+                },
+                {
+                    "type": "object",
+                    "description": "This is the object operand",
+                    "propertyNames": {
+                        "not": {
+                            "pattern": "^(and|or|not|equal|matches)$"
+                        }
+                    }
+                }
+            ]
+        },
+        "step": {
+            "oneOf": [
+                {
+                    "type": "string",
+                    "description": "Shorthand commands, like `checkout`"
+                },
+                {
+                    "type": "object",
+                    "description": "long form commands like `run:`",
+                    "propertyNames": {
+                        "pattern": "^[a-z][a-z\\d\/_-]*$",
+                        "not": {
+                            "pattern": "^(when|unless)$"
+                        }
+                    },
+                    "minProperties": 1,
+                    "maxProperties": 1,
+                    "properties": {
+                        "run": {
+                            "oneOf": [
+                                {
+                                    "type": "string"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "command": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    "required": [
+                                        "command"
+                                    ]
+                                }
+                            ]
+                        }
+                    },
+                    "additionalProperties": {
+                        "type": [
+                            "object",
+                            "string"
+                        ]
+                    }
+                },
+                {
+                    "type": "object",
+                    "description": "`when`/`unless` step",
+                    "additionalProperties": false,
+                    "minProperties": 1,
+                    "maxProperties": 1,
+                    "properties": {
+                        "when": {
+                            "type": "object",
+                            "required": [
+                                "condition",
+                                "steps"
+                            ],
+                            "properties": {
+                                "condition": {
+                                    "$ref": "#/definitions/logic"
+                                },
+                                "steps": {
+                                    "oneOf": [
+                                        {
+                                            "type": "array",
+                                            "items": {
+                                                "$ref": "#/definitions/step"
+                                            }
+                                        },
+                                        {
+                                            "$ref": "#/definitions/step"
+                                        }
+                                    ]
+                                }
+                            }
+                        },
+                        "unless": {
+                            "type": "object",
+                            "required": [
+                                "condition",
+                                "steps"
+                            ],
+                            "properties": {
+                                "condition": {
+                                    "$ref": "#/definitions/logic"
+                                },
+                                "steps": {
+                                    "oneOf": [
+                                        {
+                                            "type": "array",
+                                            "items": {
+                                                "$ref": "#/definitions/step"
+                                            }
+                                        },
+                                        {
+                                            "$ref": "#/definitions/step"
+                                        }
+                                    ]
+                                }
+                            }
+                        }
+                    }
+                }
+            ]
+        }
+    },
+    "type": "object",
+    "properties": {
+        "executors": {
+            "type": [
+                "object",
+                "null"
+            ],
+            "propertyNames": {
+                "pattern": "^[a-z][a-z\\d_-]*$"
+            },
+            "additionalProperties": {
+                "oneOf": [
+                    {
+                        "type": "object",
+                        "properties": {
+                            "description": {
+                                "type": "string"
+                            },
+                            "macos": {
+                                "type": "object",
+                                "properties": {
+                                    "xcode": {
+                                        "type": [
+                                            "string",
+                                            "number"
+                                        ]
+                                    },
+                                    "resource_class": {
+                                        "type": "string"
+                                    },
+                                    "shell": {
+                                        "type": "string"
+                                    }
+                                },
+                                "required": [
+                                    "xcode"
+                                ],
+                                "additionalProperties": false
+                            },
+                            "resource_class": {
+                                "type": "string"
+                            },
+                            "docker": {
+                                "type": "array",
+                                "minItems": 1,
+                                "items": {
+                                    "type": "object",
+                                    "properties": {
+                                        "image": {
+                                            "type": "string"
+                                        },
+                                        "name": {
+                                            "type": "string"
+                                        },
+                                        "entrypoint": {
+                                            "oneOf": [
+                                                {
+                                                    "type": "string"
+                                                },
+                                                {
+                                                    "type": "array",
+                                                    "items": {
+                                                        "type": "string"
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        "command": {
+                                            "oneOf": [
+                                                {
+                                                    "type": "string"
+                                                },
+                                                {
+                                                    "type": "array",
+                                                    "items": {
+                                                        "type": "string"
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        "user": {
+                                            "type": "string"
+                                        },
+                                        "environment": {
+                                            "oneOf": [
+                                                {
+                                                    "description": "Allow null to account for empty `environment:` declarations.",
+                                                    "type": [
+                                                        "string",
+                                                        "null"
+                                                    ]
+                                                },
+                                                {
+                                                    "description": "An array of strings in the form KEY=VALUE",
+                                                    "type": "array",
+                                                    "items": {
+                                                        "$ref": "#/definitions/environment"
+                                                    }
+                                                },
+                                                {
+                                                    "type": "object",
+                                                    "description": "The value should be a string, but we allow null, boolean and numbers too. Examples: `FOO: true` and `BAR: 2` `BAZ:`",
+                                                    "additionalProperties": {
+                                                        "type": [
+                                                            "string",
+                                                            "boolean",
+                                                            "number",
+                                                            "null"
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        "aws_auth": {
+                                            "oneOf": [
+                                                {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "aws_access_key_id": {
+                                                            "type": "string"
+                                                        },
+                                                        "aws_secret_access_key": {
+                                                            "type": "string"
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "aws_access_key_id",
+                                                        "aws_secret_access_key"
+                                                    ],
+                                                    "additionalProperties": false
+                                                },
+                                                {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "oidc_role_arn": {
+                                                            "type": "string"
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "oidc_role_arn"
+                                                    ],
+                                                    "additionalProperties": false
+                                                }
+                                            ]
+                                        },
+                                        "auth": {
+                                            "type": "object",
+                                            "properties": {
+                                                "username": {
+                                                    "type": "string"
+                                                },
+                                                "password": {
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "required": [
+                                                "username",
+                                                "password"
+                                            ],
+                                            "additionalProperties": false
+                                        }
+                                    },
+                                    "required": [
+                                        "image"
+                                    ],
+                                    "additionalProperties": false
+                                }
+                            },
+                            "working_directory": {
+                                "type": "string"
+                            },
+                            "machine": {
+                                "description": "Machine must be a boolean or a map",
+                                "oneOf": [
+                                    {
+                                        "description": "A boolean or a template parameter evaluating to a boolean",
+                                        "anyOf": [
+                                            {
+                                                "type": "string",
+                                                "pattern": " *<< *parameters.([^ ]+) *>> *"
+                                            },
+                                            {
+                                                "type": "boolean"
+                                            },
+                                            {
+                                                "type": "number"
+                                            },
+                                            {
+                                                "type": "string"
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "type": "object",
+                                        "properties": {
+                                            "enabled": {
+                                                "description": "A boolean or a template parameter evaluating to a boolean",
+                                                "anyOf": [
+                                                    {
+                                                        "type": "string",
+                                                        "pattern": " *<< *parameters.([^ ]+) *>> *"
+                                                    },
+                                                    {
+                                                        "type": "boolean"
+                                                    },
+                                                    {
+                                                        "type": "number"
+                                                    },
+                                                    {
+                                                        "type": "string"
+                                                    }
+                                                ]
+                                            },
+                                            "image": {
+                                                "type": "string"
+                                            },
+                                            "docker_layer_caching": {
+                                                "description": "A boolean or a template parameter evaluating to a boolean",
+                                                "anyOf": [
+                                                    {
+                                                        "type": "string",
+                                                        "pattern": " *<< *parameters.([^ ]+) *>> *"
+                                                    },
+                                                    {
+                                                        "type": "boolean"
+                                                    },
+                                                    {
+                                                        "type": "number"
+                                                    },
+                                                    {
+                                                        "type": "string"
+                                                    }
+                                                ]
+                                            },
+                                            "resource_class": {
+                                                "type": "string"
+                                            },
+                                            "shell": {
+                                                "type": "string"
+                                            }
+                                        },
+                                        "additionalProperties": false
+                                    }
+                                ]
+                            },
+                            "environment": {
+                                "oneOf": [
+                                    {
+                                        "description": "Allow null to account for empty `environment:` declarations.",
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ]
+                                    },
+                                    {
+                                        "description": "An array of strings in the form KEY=VALUE",
+                                        "type": "array",
+                                        "items": {
+                                            "$ref": "#/definitions/environment"
+                                        }
+                                    },
+                                    {
+                                        "type": "object",
+                                        "description": "The value should be a string, but we allow null, boolean and numbers too. Examples: `FOO: true` and `BAR: 2` `BAZ:`",
+                                        "additionalProperties": {
+                                            "type": [
+                                                "string",
+                                                "boolean",
+                                                "number",
+                                                "null"
+                                            ]
+                                        }
+                                    }
+                                ]
+                            },
+                            "shell": {
+                                "oneOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                ]
+                            },
+                            "parameters": {
+                                "description": "Parameters given to a job.",
+                                "type": "object",
+                                "additionalProperties": {
+                                    "type": "object",
+                                    "properties": {
+                                        "type": {
+                                            "type": "string",
+                                            "enum": [
+                                                "boolean",
+                                                "string",
+                                                "steps",
+                                                "enum",
+                                                "executor",
+                                                "integer",
+                                                "env_var_name"
+                                            ]
+                                        },
+                                        "default": {
+                                            "oneOf": [
+                                                {
+                                                    "type": "string"
+                                                },
+                                                {
+                                                    "type": "boolean"
+                                                },
+                                                {
+                                                    "type": "integer"
+                                                },
+                                                {
+                                                    "type": "array",
+                                                    "items": {
+                                                        "$ref": "#/definitions/step"
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        "description": {
+                                            "type": "string"
+                                        },
+                                        "enum": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    },
+                                    "additionalProperties": false,
+                                    "required": [
+                                        "type"
+                                    ]
+                                },
+                                "minProperties": 1
+                            }
+                        },
+                        "additionalProperties": false
+                    },
+                    {
+                        "type": "string",
+                        "description": "Executor may be a string reference to another executor"
+                    }
+                ]
+            }
+        },
+        "experimental": {
+            "type": "object",
+            "properties": {
+                "notify": {
+                    "type": "object",
+                    "properties": {
+                        "branches": {
+                            "type": "object",
+                            "properties": {
+                                "only": {
+                                    "oneOf": [
+                                        {
+                                            "type": "string"
+                                        },
+                                        {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    ]
+                                },
+                                "ignore": {
+                                    "oneOf": [
+                                        {
+                                            "type": "string"
+                                        },
+                                        {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    ]
+                                }
+                            },
+                            "additionalProperties": false
+                        }
+                    },
+                    "required": [
+                        "branches"
+                    ],
+                    "additionalProperties": false
+                }
+            },
+            "additionalProperties": false,
+            "required": [
+                "notify"
+            ]
+        },
+        "workflows": {
+            "type": "object",
+            "properties": {
+                "version": {
+                    "type": [
+                        "number",
+                        "string"
+                    ]
+                }
+            },
+            "propertyNames": {
+                "pattern": ".+"
+            },
+            "additionalProperties": {
+                "type": "object",
+                "properties": {
+                    "triggers": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "schedule": {
+                                    "type": "object",
+                                    "properties": {
+                                        "cron": {
+                                            "type": "string"
+                                        },
+                                        "filters": {
+                                            "type": "object",
+                                            "properties": {
+                                                "branches": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "only": {
+                                                            "oneOf": [
+                                                                {
+                                                                    "type": "string"
+                                                                },
+                                                                {
+                                                                    "type": "array",
+                                                                    "items": {
+                                                                        "type": "string"
+                                                                    }
+                                                                }
+                                                            ]
+                                                        },
+                                                        "ignore": {
+                                                            "oneOf": [
+                                                                {
+                                                                    "type": "string"
+                                                                },
+                                                                {
+                                                                    "type": "array",
+                                                                    "items": {
+                                                                        "type": "string"
+                                                                    }
+                                                                }
+                                                            ]
+                                                        }
+                                                    },
+                                                    "additionalProperties": false
+                                                }
+                                            },
+                                            "additionalProperties": false
+                                        }
+                                    }
+                                }
+                            },
+                            "additionalProperties": false
+                        }
+                    },
+                    "max_auto_reruns": {
+                        "type": "integer",
+                        "minimum": 1,
+                        "maximum": 5
+                    },
+                    "when": {
+                        "$ref": "#/definitions/logic"
+                    },
+                    "unless": {
+                        "$ref": "#/definitions/logic"
+                    },
+                    "jobs": {
+                        "type": "array",
+                        "minItems": 1,
+                        "items": {
+                            "oneOf": [
+                                {
+                                    "type": "string"
+                                },
+                                {
+                                    "type": "object",
+                                    "maxProperties": 1,
+                                    "minProperties": 0,
+                                    "additionalProperties": {
+                                        "type": "object",
+                                        "properties": {
+                                            "requires": {
+                                                "type": "array",
+                                                "items": {
+                                                    "oneOf": [
+                                                        {
+                                                            "type": "string"
+                                                        },
+                                                        {
+                                                            "type": "object",
+                                                            "minProperties": 1,
+                                                            "maxProperties": 1,
+                                                            "patternProperties": {
+                                                                "^[A-Za-z][A-Za-z\\s\\d_-]*$": {
+                                                                    "oneOf": [
+                                                                        {
+                                                                            "type": "string",
+                                                                            "enum": [
+                                                                                "success",
+                                                                                "failed",
+                                                                                "canceled"
+                                                                            ]
+                                                                        },
+                                                                        {
+                                                                            "type": "array",
+                                                                            "minLength": 1,
+                                                                            "items": {
+                                                                                "type": "string",
+                                                                                "enum": [
+                                                                                    "success",
+                                                                                    "failed",
+                                                                                    "canceled"
+                                                                                ]
+                                                                            }
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            }
+                                                        }
+                                                    ]
+                                                }
+                                            },
+                                            "filters": {
+                                                "type": "object",
+                                                "description": "This is similar to to other `filters` in config, but has an additional key, `tags`",
+                                                "properties": {
+                                                    "branches": {
+                                                        "type": "object",
+                                                        "properties": {
+                                                            "only": {
+                                                                "oneOf": [
+                                                                    {
+                                                                        "type": "string"
+                                                                    },
+                                                                    {
+                                                                        "type": "array",
+                                                                        "items": {
+                                                                            "type": "string"
+                                                                        }
+                                                                    }
+                                                                ]
+                                                            },
+                                                            "ignore": {
+                                                                "oneOf": [
+                                                                    {
+                                                                        "type": "string"
+                                                                    },
+                                                                    {
+                                                                        "type": "array",
+                                                                        "items": {
+                                                                            "type": "string"
+                                                                        }
+                                                                    }
+                                                                ]
+                                                            }
+                                                        },
+                                                        "additionalProperties": false
+                                                    },
+                                                    "tags": {
+                                                        "type": "object",
+                                                        "properties": {
+                                                            "only": {
+                                                                "oneOf": [
+                                                                    {
+                                                                        "type": "string"
+                                                                    },
+                                                                    {
+                                                                        "type": "array",
+                                                                        "items": {
+                                                                            "type": "string"
+                                                                        }
+                                                                    }
+                                                                ]
+                                                            },
+                                                            "ignore": {
+                                                                "oneOf": [
+                                                                    {
+                                                                        "type": "string"
+                                                                    },
+                                                                    {
+                                                                        "type": "array",
+                                                                        "items": {
+                                                                            "type": "string"
+                                                                        }
+                                                                    }
+                                                                ]
+                                                            }
+                                                        },
+                                                        "additionalProperties": false
+                                                    }
+                                                },
+                                                "additionalProperties": false
+                                            },
+                                            "context": {
+                                                "oneOf": [
+                                                    {
+                                                        "type": "string"
+                                                    },
+                                                    {
+                                                        "type": "array",
+                                                        "items": {
+                                                            "type": "string"
+                                                        }
+                                                    }
+                                                ]
+                                            },
+                                            "type": {
+                                                "type": "string"
+                                            },
+                                            "pre-steps": {
+                                                "steps": {
+                                                    "type": "array",
+                                                    "items": {
+                                                        "$ref": "#/definitions/step"
+                                                    },
+                                                    "minItems": 1
+                                                }
+                                            },
+                                            "post-steps": {
+                                                "steps": {
+                                                    "type": "array",
+                                                    "items": {
+                                                        "$ref": "#/definitions/step"
+                                                    },
+                                                    "minItems": 1
+                                                }
+                                            },
+                                            "matrix": {
+                                                "type": "object",
+                                                "required": [
+                                                    "parameters"
+                                                ],
+                                                "properties": {
+                                                    "parameters": {
+                                                        "type": "object"
+                                                    },
+                                                    "exclude": {
+                                                        "type": "array",
+                                                        "items": {
+                                                            "type": "object"
+                                                        }
+                                                    },
+                                                    "alias": {
+                                                        "type": "string"
+                                                    }
+                                                }
+                                            },
+                                            "serial-group": {
+                                                "type": "string",
+                                                "minLength": 1
+                                            },
+                                            "override-with": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                },
+                "required": [
+                    "jobs"
+                ],
+                "not": {
+                    "description": "cannot use both 'when' and 'unless'",
+                    "allOf": [
+                        {
+                            "required": [
+                                "when"
+                            ]
+                        },
+                        {
+                            "required": [
+                                "unless"
+                            ]
+                        }
+                    ]
+                }
+            }
+        },
+        "jobs": {
+            "description": "Any string key is allowed as job name.",
+            "type": "object",
+            "propertyNames": {
+                "type": "string",
+                "pattern": "^[A-Za-z][A-Za-z\\s\\d_-]*$"
+            },
+            "additionalProperties": {
+                "oneOf": [
+                    {
+                        "title": "CircleCI Orb: Jobs",
+                        "type": "object",
+                        "properties": {
+                            "description": {
+                                "type": "string"
+                            },
+                            "type": {
+                                "type": "string",
+                                "description": "The job type. Further validation is handled by the language server."
+                            },
+                            "parallelism": {
+                                "description": "A integer or a parameter evaluating to a integer",
+                                "anyOf": [
+                                    {
+                                        "oneOf": [
+                                            {
+                                                "type": "string",
+                                                "pattern": " *<< *parameters.([^ ]+) *>> *"
+                                            },
+                                            {
+                                                "type": "string",
+                                                "pattern": " *<< *pipeline.parameters.([^ ]+) *>> *"
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "type": "integer"
+                                    }
+                                ]
+                            },
+                            "macos": {
+                                "type": "object",
+                                "properties": {
+                                    "xcode": {
+                                        "type": [
+                                            "string",
+                                            "number"
+                                        ]
+                                    },
+                                    "resource_class": {
+                                        "type": "string"
+                                    },
+                                    "shell": {
+                                        "type": "string"
+                                    }
+                                },
+                                "required": [
+                                    "xcode"
+                                ],
+                                "additionalProperties": false
+                            },
+                            "resource_class": {
+                                "type": "string"
+                            },
+                            "docker": {
+                                "type": "array",
+                                "minItems": 1,
+                                "items": {
+                                    "type": "object",
+                                    "properties": {
+                                        "image": {
+                                            "type": "string"
+                                        },
+                                        "name": {
+                                            "type": "string"
+                                        },
+                                        "entrypoint": {
+                                            "oneOf": [
+                                                {
+                                                    "type": "string"
+                                                },
+                                                {
+                                                    "type": "array",
+                                                    "items": {
+                                                        "type": "string"
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        "command": {
+                                            "oneOf": [
+                                                {
+                                                    "type": "string"
+                                                },
+                                                {
+                                                    "type": "array",
+                                                    "items": {
+                                                        "type": "string"
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        "user": {
+                                            "type": "string"
+                                        },
+                                        "environment": {
+                                            "oneOf": [
+                                                {
+                                                    "description": "Allow null to account for empty `environment:` declarations.",
+                                                    "type": [
+                                                        "string",
+                                                        "null"
+                                                    ]
+                                                },
+                                                {
+                                                    "description": "An array of strings in the form KEY=VALUE",
+                                                    "type": "array",
+                                                    "items": {
+                                                        "$ref": "#/definitions/environment"
+                                                    }
+                                                },
+                                                {
+                                                    "type": "object",
+                                                    "description": "The value should be a string, but we allow null, boolean and numbers too. Examples: `FOO: true` and `BAR: 2` `BAZ:`",
+                                                    "additionalProperties": {
+                                                        "type": [
+                                                            "string",
+                                                            "boolean",
+                                                            "number",
+                                                            "null"
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        "aws_auth": {
+                                            "oneOf": [
+                                                {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "aws_access_key_id": {
+                                                            "type": "string"
+                                                        },
+                                                        "aws_secret_access_key": {
+                                                            "type": "string"
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "aws_access_key_id",
+                                                        "aws_secret_access_key"
+                                                    ],
+                                                    "additionalProperties": false
+                                                },
+                                                {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "oidc_role_arn": {
+                                                            "type": "string"
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "oidc_role_arn"
+                                                    ],
+                                                    "additionalProperties": false
+                                                }
+                                            ]
+                                        },
+                                        "auth": {
+                                            "type": "object",
+                                            "properties": {
+                                                "username": {
+                                                    "type": "string"
+                                                },
+                                                "password": {
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "required": [
+                                                "username",
+                                                "password"
+                                            ],
+                                            "additionalProperties": false
+                                        }
+                                    },
+                                    "required": [
+                                        "image"
+                                    ],
+                                    "additionalProperties": false
+                                }
+                            },
+                            "steps": {
+                                "type": "array",
+                                "items": {
+                                    "$ref": "#/definitions/step"
+                                },
+                                "minItems": 1
+                            },
+                            "working_directory": {
+                                "type": "string"
+                            },
+                            "retention": {
+                                "type": "object",
+                                "properties": {
+                                    "caches": {
+                                        "type": "string",
+                                        "pattern": "^([1-9]|1[0-5])d$"
+                                    }
+                                },
+                                "additionalProperties": false
+                            },
+                            "circleci_ip_ranges": {
+                                "type": "boolean"
+                            },
+                            "machine": {
+                                "description": "Machine must be a boolean or a map",
+                                "oneOf": [
+                                    {
+                                        "description": "A boolean or a template parameter evaluating to a boolean",
+                                        "anyOf": [
+                                            {
+                                                "type": "string",
+                                                "pattern": " *<< *parameters.([^ ]+) *>> *"
+                                            },
+                                            {
+                                                "type": "boolean"
+                                            },
+                                            {
+                                                "type": "number"
+                                            },
+                                            {
+                                                "type": "string"
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "type": "object",
+                                        "properties": {
+                                            "enabled": {
+                                                "description": "A boolean or a template parameter evaluating to a boolean",
+                                                "anyOf": [
+                                                    {
+                                                        "type": "string",
+                                                        "pattern": " *<< *parameters.([^ ]+) *>> *"
+                                                    },
+                                                    {
+                                                        "type": "boolean"
+                                                    },
+                                                    {
+                                                        "type": "number"
+                                                    },
+                                                    {
+                                                        "type": "string"
+                                                    }
+                                                ]
+                                            },
+                                            "image": {
+                                                "type": "string"
+                                            },
+                                            "docker_layer_caching": {
+                                                "description": "A boolean or a template parameter evaluating to a boolean",
+                                                "anyOf": [
+                                                    {
+                                                        "type": "string",
+                                                        "pattern": " *<< *parameters.([^ ]+) *>> *"
+                                                    },
+                                                    {
+                                                        "type": "boolean"
+                                                    },
+                                                    {
+                                                        "type": "number"
+                                                    },
+                                                    {
+                                                        "type": "string"
+                                                    }
+                                                ]
+                                            },
+                                            "resource_class": {
+                                                "type": "string"
+                                            },
+                                            "shell": {
+                                                "type": "string"
+                                            }
+                                        },
+                                        "additionalProperties": false
+                                    }
+                                ]
+                            },
+                            "environment": {
+                                "oneOf": [
+                                    {
+                                        "description": "Allow null to account for empty `environment:` declarations.",
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ]
+                                    },
+                                    {
+                                        "description": "An array of strings in the form KEY=VALUE",
+                                        "type": "array",
+                                        "items": {
+                                            "$ref": "#/definitions/environment"
+                                        }
+                                    },
+                                    {
+                                        "type": "object",
+                                        "description": "The value should be a string, but we allow null, boolean and numbers too. Examples: `FOO: true` and `BAR: 2` `BAZ:`",
+                                        "additionalProperties": {
+                                            "type": [
+                                                "string",
+                                                "boolean",
+                                                "number",
+                                                "null"
+                                            ]
+                                        }
+                                    }
+                                ]
+                            },
+                            "executor": {
+                                "oneOf": [
+                                    {
+                                        "type": "string",
+                                        "description": "short executor invocation, name of executor"
+                                    },
+                                    {
+                                        "type": "object",
+                                        "description": "executor invocation with arguments, i.e. parameters",
+                                        "minProperties": 1,
+                                        "additionalProperties": true,
+                                        "properties": {
+                                            "name": {
+                                                "type": "string"
+                                            }
+                                        },
+                                        "required": [
+                                            "name"
+                                        ]
+                                    }
+                                ]
+                            },
+                            "shell": {
+                                "oneOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                ]
+                            },
+                            "parameters": {
+                                "description": "Parameters given to a job.",
+                                "type": "object",
+                                "additionalProperties": {
+                                    "type": "object",
+                                    "properties": {
+                                        "type": {
+                                            "type": "string",
+                                            "enum": [
+                                                "boolean",
+                                                "string",
+                                                "steps",
+                                                "enum",
+                                                "executor",
+                                                "integer",
+                                                "env_var_name"
+                                            ]
+                                        },
+                                        "default": {
+                                            "oneOf": [
+                                                {
+                                                    "type": "string"
+                                                },
+                                                {
+                                                    "type": "boolean"
+                                                },
+                                                {
+                                                    "type": "integer"
+                                                },
+                                                {
+                                                    "type": "array",
+                                                    "items": {
+                                                        "$ref": "#/definitions/step"
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        "description": {
+                                            "type": "string"
+                                        },
+                                        "enum": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    },
+                                    "additionalProperties": false,
+                                    "required": [
+                                        "type"
+                                    ]
+                                },
+                                "minProperties": 1
+                            }
+                        },
+                        "required": [
+                            "steps"
+                        ],
+                        "additionalProperties": false,
+                        "anyOf": [
+                            {
+                                "description": "A job must have one of `docker`, `machine`, `macos` or `executor` (which can provide docker/machine/macos information).",
+                                "type": "object",
+                                "required": [
+                                    "executor"
+                                ]
+                            },
+                            {
+                                "oneOf": [
+                                    {
+                                        "type": "object",
+                                        "required": [
+                                            "machine"
+                                        ]
+                                    },
+                                    {
+                                        "type": "object",
+                                        "required": [
+                                            "docker"
+                                        ]
+                                    },
+                                    {
+                                        "type": "object",
+                                        "required": [
+                                            "macos"
+                                        ]
+                                    }
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        "title": "Job with type explicitly specified. Some job types like approval or no-op don't require steps or executors defined to be valid, so this rule allows them to be omitted if type is specified.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "type": {
+                                "type": "string",
+                                "description": "The job type. Further validation is handled by the language server."
+                            }
+                        }
+                    },
+                    {
+                        "type": "string",
+                        "description": "Job may be a string reference to another job"
+                    }
+                ]
+            }
+        },
+        "orbs": {
+            "type": [
+                "object",
+                "null"
+            ],
+            "additionalProperties": {
+                "oneOf": [
+                    {
                         "type": "string"
-                      }
-										}
-									}
-								}
-							]
-						}
-					}
-				},
-				"required": ["jobs"],
-				"not": {
-					"description": "cannot use both 'when' and 'unless'",
-					"allOf": [
-						{
-							"required": ["when"]
-						},
-						{
-							"required": ["unless"]
-						}
-					]
-				}
-			}
-		},
-		"jobs": {
-			"description": "Any string key is allowed as job name.",
-			"type": "object",
-			"propertyNames": {
-				"type": "string",
-				"pattern": "^[A-Za-z][A-Za-z\\s\\d_-]*$"
-			},
-			"additionalProperties": {
-				"oneOf": [
-					{
-						"title": "CircleCI Orb: Jobs",
-						"type": "object",
-						"properties": {
-							"description": {
-								"type": "string"
-							},
-							"type": {
-								"type": "string",
-								"description": "The job type. Further validation is handled by the language server."
-							},
-							"parallelism": {
-								"description": "A integer or a parameter evaluating to a integer",
-								"anyOf": [
-									{
-										"oneOf": [
-											{
-												"type": "string",
-												"pattern": " *<< *parameters.([^ ]+) *>> *"
-											},
-											{
-												"type": "string",
-												"pattern": " *<< *pipeline.parameters.([^ ]+) *>> *"
-											}
-										]
-									},
-									{
-										"type": "integer"
-									}
-								]
-							},
-							"macos": {
-								"type": "object",
-								"properties": {
-									"xcode": {
-										"type": ["string", "number"]
-									},
-									"resource_class": {
-										"type": "string"
-									},
-									"shell": {
-										"type": "string"
-									}
-								},
-								"required": ["xcode"],
-								"additionalProperties": false
-							},
-							"resource_class": {
-								"type": "string"
-							},
-							"docker": {
-								"type": "array",
-								"minItems": 1,
-								"items": {
-									"type": "object",
-									"properties": {
-										"image": {
-											"type": "string"
-										},
-										"name": {
-											"type": "string"
-										},
-										"entrypoint": {
-											"oneOf": [
-												{
-													"type": "string"
-												},
-												{
-													"type": "array",
-													"items": {
-														"type": "string"
-													}
-												}
-											]
-										},
-										"command": {
-											"oneOf": [
-												{
-													"type": "string"
-												},
-												{
-													"type": "array",
-													"items": {
-														"type": "string"
-													}
-												}
-											]
-										},
-										"user": {
-											"type": "string"
-										},
-										"environment": {
-											"oneOf": [
-												{
-													"description": "Allow null to account for empty `environment:` declarations.",
-													"type": ["string", "null"]
-												},
-												{
-													"description": "An array of strings in the form KEY=VALUE",
-													"type": "array",
-													"items": {
-														"$ref": "#/definitions/environment"
-													}
-												},
-												{
-													"type": "object",
-													"description": "The value should be a string, but we allow null, boolean and numbers too. Examples: `FOO: true` and `BAR: 2` `BAZ:`",
-													"additionalProperties": {
-														"type": [
-															"string",
-															"boolean",
-															"number",
-															"null"
-														]
-													}
-												}
-											]
-										},
-										"aws_auth": {
-											"oneOf": [
-												{
-													"type": "object",
-													"properties": {
-														"aws_access_key_id": {
-															"type": "string"
-														},
-														"aws_secret_access_key": {
-															"type": "string"
-														}
-													},
-													"required": [
-														"aws_access_key_id",
-														"aws_secret_access_key"
-													],
-													"additionalProperties": false
-												},
-												{
-													"type": "object",
-													"properties": {
-														"oidc_role_arn": {
-															"type": "string"
-														}
-													},
-													"required": [
-														"oidc_role_arn"
-													],
-													"additionalProperties": false
-												}
-											]
-										},
-										"auth": {
-											"type": "object",
-											"properties": {
-												"username": {
-													"type": "string"
-												},
-												"password": {
-													"type": "string"
-												}
-											},
-											"required": [
-												"username",
-												"password"
-											],
-											"additionalProperties": false
-										}
-									},
-									"required": ["image"],
-									"additionalProperties": false
-								}
-							},
-							"steps": {
-								"type": "array",
-								"items": {
-									"$ref": "#/definitions/step"
-								},
-								"minItems": 1
-							},
-							"working_directory": {
-								"type": "string"
-							},
-							"retention": {
-								"type": "object",
-								"properties": {
-									"caches": {
-										"type": "string",
-										"pattern": "^([1-9]|1[0-5])d$"
-									}
-								},
-								"additionalProperties": false
-							},
-							"circleci_ip_ranges": {
-								"type": "boolean"
-							},
-							"machine": {
-								"description": "Machine must be a boolean or a map",
-								"oneOf": [
-									{
-										"description": "A boolean or a template parameter evaluating to a boolean",
-										"anyOf": [
-											{
-												"type": "string",
-												"pattern": " *<< *parameters.([^ ]+) *>> *"
-											},
-											{
-												"type": "boolean"
-											},
-											{
-												"type": "number"
-											},
-											{
-												"type": "string"
-											}
-										]
-									},
-									{
-										"type": "object",
-										"properties": {
-											"enabled": {
-												"description": "A boolean or a template parameter evaluating to a boolean",
-												"anyOf": [
-													{
-														"type": "string",
-														"pattern": " *<< *parameters.([^ ]+) *>> *"
-													},
-													{
-														"type": "boolean"
-													},
-													{
-														"type": "number"
-													},
-													{
-														"type": "string"
-													}
-												]
-											},
-											"image": {
-												"type": "string"
-											},
-											"docker_layer_caching": {
-												"description": "A boolean or a template parameter evaluating to a boolean",
-												"anyOf": [
-													{
-														"type": "string",
-														"pattern": " *<< *parameters.([^ ]+) *>> *"
-													},
-													{
-														"type": "boolean"
-													},
-													{
-														"type": "number"
-													},
-													{
-														"type": "string"
-													}
-												]
-											},
-											"resource_class": {
-												"type": "string"
-											},
-											"shell": {
-												"type": "string"
-											}
-										},
-										"additionalProperties": false
-									}
-								]
-							},
-							"environment": {
-								"oneOf": [
-									{
-										"description": "Allow null to account for empty `environment:` declarations.",
-										"type": ["string", "null"]
-									},
-									{
-										"description": "An array of strings in the form KEY=VALUE",
-										"type": "array",
-										"items": {
-											"$ref": "#/definitions/environment"
-										}
-									},
-									{
-										"type": "object",
-										"description": "The value should be a string, but we allow null, boolean and numbers too. Examples: `FOO: true` and `BAR: 2` `BAZ:`",
-										"additionalProperties": {
-											"type": [
-												"string",
-												"boolean",
-												"number",
-												"null"
-											]
-										}
-									}
-								]
-							},
-							"executor": {
-								"oneOf": [
-									{
-										"type": "string",
-										"description": "short executor invocation, name of executor"
-									},
-									{
-										"type": "object",
-										"description": "executor invocation with arguments, i.e. parameters",
-										"minProperties": 1,
-										"additionalProperties": true,
-										"properties": {
-											"name": {
-												"type": "string"
-											}
-										},
-										"required": ["name"]
-									}
-								]
-							},
-							"shell": {
-								"oneOf": [
-									{
-										"type": "string"
-									},
-									{
-										"type": "array",
-										"items": {
-											"type": "string"
-										}
-									}
-								]
-							},
-							"parameters": {
-								"description": "Parameters given to a job.",
-								"type": "object",
-								"additionalProperties": {
-									"type": "object",
-									"properties": {
-										"type": {
-											"type": "string",
-											"enum": [
-												"boolean",
-												"string",
-												"steps",
-												"enum",
-												"executor",
-												"integer",
-												"env_var_name"
-											]
-										},
-										"default": {
-											"oneOf": [
-												{
-													"type": "string"
-												},
-												{
-													"type": "boolean"
-												},
-												{
-													"type": "integer"
-												},
-												{
-													"type": "array",
-													"items": {
-														"$ref": "#/definitions/step"
-													}
-												}
-											]
-										},
-										"description": {
-											"type": "string"
-										},
-										"enum": {
-											"type": "array",
-											"items": {
-												"type": "string"
-											}
-										}
-									},
-									"additionalProperties": false,
-									"required": ["type"]
-								},
-								"minProperties": 1
-							}
-						},
-						"required": ["steps"],
-						"additionalProperties": false,
-						"anyOf": [
-							{
-								"description": "A job must have one of `docker`, `machine`, `macos` or `executor` (which can provide docker/machine/macos information).",
-								"type": "object",
-								"required": ["executor"]
-							},
-							{
-								"oneOf": [
-									{
-										"type": "object",
-										"required": ["machine"]
-									},
-									{
-										"type": "object",
-										"required": ["docker"]
-									},
-									{
-										"type": "object",
-										"required": ["macos"]
-									}
-								]
-							}
-						]
-					},
-					{
-						"title": "Job with type explicitly specified. Some job types like approval or no-op don't require steps or executors defined to be valid, so this rule allows them to be omitted if type is specified.",
-						"type": "object",
-						"additionalProperties": false,
-						"properties": {
-							"type": {
-								"type": "string",
-								"description": "The job type. Further validation is handled by the language server."
-							}
-						}
-					},
-					{
-						"type": "string",
-						"description": "Job may be a string reference to another job"
-					}
-				]
-			}
-		},
-		"orbs": {
-			"type": ["object", "null"],
-			"additionalProperties": {
-				"oneOf": [
-					{
-						"type": "string"
-					},
-					{
-						"type": "object",
-						"properties": {
-							"jobs": {
-								"description": "Any string key is allowed as job name.",
-								"type": "object",
-								"propertyNames": {
-									"type": "string",
-									"pattern": "^[A-Za-z][A-Za-z\\s\\d_-]*$"
-								},
-								"additionalProperties": {
-									"oneOf": [
-										{
-											"title": "CircleCI Orb: Jobs",
-											"type": "object",
-											"properties": {
-												"description": {
-													"type": "string"
-												},
-												"parallelism": {
-													"description": "A integer or a parameter evaluating to a integer",
-													"anyOf": [
-														{
-															"oneOf": [
-																{
-																	"type": "string",
-																	"pattern": " *<< *parameters.([^ ]+) *>> *"
-																},
-																{
-																	"type": "string",
-																	"pattern": " *<< *pipeline.parameters.([^ ]+) *>> *"
-																}
-															]
-														},
-														{
-															"type": "integer"
-														}
-													]
-												},
-												"macos": {
-													"type": "object",
-													"properties": {
-														"xcode": {
-															"type": [
-																"string",
-																"number"
-															]
-														},
-														"resource_class": {
-															"type": "string"
-														},
-														"shell": {
-															"type": "string"
-														}
-													},
-													"required": ["xcode"],
-													"additionalProperties": false
-												},
-												"resource_class": {
-													"type": "string"
-												},
-												"docker": {
-													"type": "array",
-													"minItems": 1,
-													"items": {
-														"type": "object",
-														"properties": {
-															"image": {
-																"type": "string"
-															},
-															"name": {
-																"type": "string"
-															},
-															"entrypoint": {
-																"oneOf": [
-																	{
-																		"type": "string"
-																	},
-																	{
-																		"type": "array",
-																		"items": {
-																			"type": "string"
-																		}
-																	}
-																]
-															},
-															"command": {
-																"oneOf": [
-																	{
-																		"type": "string"
-																	},
-																	{
-																		"type": "array",
-																		"items": {
-																			"type": "string"
-																		}
-																	}
-																]
-															},
-															"user": {
-																"type": "string"
-															},
-															"environment": {
-																"oneOf": [
-																	{
-																		"description": "Allow null to account for empty `environment:` declarations.",
-																		"type": [
-																			"string",
-																			"null"
-																		]
-																	},
-																	{
-																		"description": "An array of strings in the form KEY=VALUE",
-																		"type": "array",
-																		"items": {
-																			"$ref": "#/definitions/environment"
-																		}
-																	},
-																	{
-																		"type": "object",
-																		"description": "The value should be a string, but we allow null, boolean and numbers too. Examples: `FOO: true` and `BAR: 2` `BAZ:`",
-																		"additionalProperties": {
-																			"type": [
-																				"string",
-																				"boolean",
-																				"number",
-																				"null"
-																			]
-																		}
-																	}
-																]
-															},
-															"aws_auth": {
-																"oneOf": [
-																	{
-																		"type": "object",
-																		"properties": {
-																			"aws_access_key_id": {
-																				"type": "string"
-																			},
-																			"aws_secret_access_key": {
-																				"type": "string"
-																			}
-																		},
-																		"required": [
-																			"aws_access_key_id",
-																			"aws_secret_access_key"
-																		],
-																		"additionalProperties": false
-																	},
-																	{
-																		"type": "object",
-																		"properties": {
-																			"oidc_role_arn": {
-																				"type": "string"
-																			}
-																		},
-																		"required": [
-																			"oidc_role_arn"
-																		],
-																		"additionalProperties": false
-																	}
-																]
-															},
-															"auth": {
-																"type": "object",
-																"properties": {
-																	"username": {
-																		"type": "string"
-																	},
-																	"password": {
-																		"type": "string"
-																	}
-																},
-																"required": [
-																	"username",
-																	"password"
-																],
-																"additionalProperties": false
-															}
-														},
-														"required": ["image"],
-														"additionalProperties": false
-													}
-												},
-												"steps": {
-													"type": "array",
-													"items": {
-														"$ref": "#/definitions/step"
-													},
-													"minItems": 1
-												},
-												"working_directory": {
-													"type": "string"
-												},
-												"circleci_ip_ranges": {
-													"type": "boolean"
-												},
-												"machine": {
-													"description": "Machine must be a boolean or a map",
-													"oneOf": [
-														{
-															"description": "A boolean or a template parameter evaluating to a boolean",
-															"anyOf": [
-																{
-																	"type": "string",
-																	"pattern": " *<< *parameters.([^ ]+) *>> *"
-																},
-																{
-																	"type": "boolean"
-																},
-																{
-																	"type": "number"
-																},
-																{
-																	"type": "string"
-																}
-															]
-														},
-														{
-															"type": "object",
-															"properties": {
-																"enabled": {
-																	"description": "A boolean or a template parameter evaluating to a boolean",
-																	"anyOf": [
-																		{
-																			"type": "string",
-																			"pattern": " *<< *parameters.([^ ]+) *>> *"
-																		},
-																		{
-																			"type": "boolean"
-																		},
-																		{
-																			"type": "number"
-																		},
-																		{
-																			"type": "string"
-																		}
-																	]
-																},
-																"image": {
-																	"type": "string"
-																},
-																"docker_layer_caching": {
-																	"description": "A boolean or a template parameter evaluating to a boolean",
-																	"anyOf": [
-																		{
-																			"type": "string",
-																			"pattern": " *<< *parameters.([^ ]+) *>> *"
-																		},
-																		{
-																			"type": "boolean"
-																		},
-																		{
-																			"type": "number"
-																		},
-																		{
-																			"type": "string"
-																		}
-																	]
-																},
-																"resource_class": {
-																	"type": "string"
-																},
-																"shell": {
-																	"type": "string"
-																}
-															},
-															"additionalProperties": false
-														}
-													]
-												},
-												"environment": {
-													"oneOf": [
-														{
-															"description": "Allow null to account for empty `environment:` declarations.",
-															"type": [
-																"string",
-																"null"
-															]
-														},
-														{
-															"description": "An array of strings in the form KEY=VALUE",
-															"type": "array",
-															"items": {
-																"$ref": "#/definitions/environment"
-															}
-														},
-														{
-															"type": "object",
-															"description": "The value should be a string, but we allow null, boolean and numbers too. Examples: `FOO: true` and `BAR: 2` `BAZ:`",
-															"additionalProperties": {
-																"type": [
-																	"string",
-																	"boolean",
-																	"number",
-																	"null"
-																]
-															}
-														}
-													]
-												},
-												"executor": {
-													"oneOf": [
-														{
-															"type": "string",
-															"description": "short executor invocation, name of executor"
-														},
-														{
-															"type": "object",
-															"description": "executor invocation with arguments, i.e. parameters",
-															"minProperties": 1,
-															"additionalProperties": true,
-															"properties": {
-																"name": {
-																	"type": "string"
-																}
-															},
-															"required": ["name"]
-														}
-													]
-												},
-												"shell": {
-													"oneOf": [
-														{
-															"type": "string"
-														},
-														{
-															"type": "array",
-															"items": {
-																"type": "string"
-															}
-														}
-													]
-												},
-												"parameters": {
-													"description": "Parameters given to a job.",
-													"type": "object",
-													"additionalProperties": {
-														"type": "object",
-														"properties": {
-															"type": {
-																"type": "string",
-																"enum": [
-																	"boolean",
-																	"string",
-																	"steps",
-																	"enum",
-																	"executor",
-																	"integer",
-																	"env_var_name"
-																]
-															},
-															"default": {
-																"oneOf": [
-																	{
-																		"type": "string"
-																	},
-																	{
-																		"type": "boolean"
-																	},
-																	{
-																		"type": "integer"
-																	},
-																	{
-																		"type": "array",
-																		"items": {
-																			"$ref": "#/definitions/step"
-																		}
-																	}
-																]
-															},
-															"description": {
-																"type": "string"
-															},
-															"enum": {
-																"type": "array",
-																"items": {
-																	"type": "string"
-																}
-															}
-														},
-														"additionalProperties": false,
-														"required": ["type"]
-													},
-													"minProperties": 1
-												}
-											},
-											"required": ["steps"],
-											"additionalProperties": false,
-											"anyOf": [
-												{
-													"description": "A job must have one of `docker`, `machine`, `macos` or `executor` (which can provide docker/machine/macos information).",
-													"type": "object",
-													"required": ["executor"]
-												},
-												{
-													"oneOf": [
-														{
-															"type": "object",
-															"required": [
-																"machine"
-															]
-														},
-														{
-															"type": "object",
-															"required": [
-																"docker"
-															]
-														},
-														{
-															"type": "object",
-															"required": [
-																"macos"
-															]
-														}
-													]
-												}
-											]
-										},
-										{
-											"type": "string",
-											"description": "Job may be a string reference to another job"
-										}
-									]
-								}
-							},
-							"commands": {
-								"type": "object",
-								"propertyNames": {
-									"pattern": "^[a-z][a-z\\d_-]*$"
-								},
-								"additionalProperties": {
-									"oneOf": [
-										{
-											"type": "object",
-											"properties": {
-												"description": {
-													"type": "string"
-												},
-												"parameters": {
-													"description": "Parameters given to a step.",
-													"type": "object",
-													"additionalProperties": {
-														"type": "object",
-														"properties": {
-															"type": {
-																"type": "string",
-																"enum": [
-																	"boolean",
-																	"string",
-																	"steps",
-																	"enum",
-																	"executor",
-																	"integer",
-																	"env_var_name"
-																]
-															},
-															"default": {
-																"oneOf": [
-																	{
-																		"type": "string"
-																	},
-																	{
-																		"type": "boolean"
-																	},
-																	{
-																		"type": "integer"
-																	},
-																	{
-																		"type": "array",
-																		"items": {
-																			"$ref": "#/definitions/step"
-																		}
-																	}
-																]
-															},
-															"description": {
-																"type": "string"
-															},
-															"enum": {
-																"type": "array",
-																"items": {
-																	"type": "string"
-																}
-															}
-														},
-														"additionalProperties": false,
-														"required": ["type"]
-													},
-													"minProperties": 1
-												},
-												"steps": {
-													"type": "array",
-													"items": {
-														"$ref": "#/definitions/step"
-													},
-													"minItems": 1
-												}
-											},
-											"required": ["steps"],
-											"additionalProperties": false
-										},
-										{
-											"type": "string",
-											"description": "Command may be a string reference to another command"
-										}
-									]
-								}
-							},
-							"executors": {
-								"type": "object",
-								"propertyNames": {
-									"pattern": "^[a-z][a-z\\d_-]*$"
-								},
-								"additionalProperties": {
-									"oneOf": [
-										{
-											"type": "object",
-											"properties": {
-												"description": {
-													"type": "string"
-												},
-												"macos": {
-													"type": "object",
-													"properties": {
-														"xcode": {
-															"type": [
-																"string",
-																"number"
-															]
-														},
-														"resource_class": {
-															"type": "string"
-														},
-														"shell": {
-															"type": "string"
-														}
-													},
-													"required": ["xcode"],
-													"additionalProperties": false
-												},
-												"resource_class": {
-													"type": "string"
-												},
-												"docker": {
-													"type": "array",
-													"minItems": 1,
-													"items": {
-														"type": "object",
-														"properties": {
-															"image": {
-																"type": "string"
-															},
-															"name": {
-																"type": "string"
-															},
-															"entrypoint": {
-																"oneOf": [
-																	{
-																		"type": "string"
-																	},
-																	{
-																		"type": "array",
-																		"items": {
-																			"type": "string"
-																		}
-																	}
-																]
-															},
-															"command": {
-																"oneOf": [
-																	{
-																		"type": "string"
-																	},
-																	{
-																		"type": "array",
-																		"items": {
-																			"type": "string"
-																		}
-																	}
-																]
-															},
-															"user": {
-																"type": "string"
-															},
-															"environment": {
-																"oneOf": [
-																	{
-																		"description": "Allow null to account for empty `environment:` declarations.",
-																		"type": [
-																			"string",
-																			"null"
-																		]
-																	},
-																	{
-																		"description": "An array of strings in the form KEY=VALUE",
-																		"type": "array",
-																		"items": {
-																			"$ref": "#/definitions/environment"
-																		}
-																	},
-																	{
-																		"type": "object",
-																		"description": "The value should be a string, but we allow null, boolean and numbers too. Examples: `FOO: true` and `BAR: 2` `BAZ:`",
-																		"additionalProperties": {
-																			"type": [
-																				"string",
-																				"boolean",
-																				"number",
-																				"null"
-																			]
-																		}
-																	}
-																]
-															},
-															"aws_auth": {
-																"oneOf": [
-																	{
-																		"type": "object",
-																		"properties": {
-																			"aws_access_key_id": {
-																				"type": "string"
-																			},
-																			"aws_secret_access_key": {
-																				"type": "string"
-																			}
-																		},
-																		"required": [
-																			"aws_access_key_id",
-																			"aws_secret_access_key"
-																		],
-																		"additionalProperties": false
-																	},
-																	{
-																		"type": "object",
-																		"properties": {
-																			"oidc_role_arn": {
-																				"type": "string"
-																			}
-																		},
-																		"required": [
-																			"oidc_role_arn"
-																		],
-																		"additionalProperties": false
-																	}
-																]
-															},
-															"auth": {
-																"type": "object",
-																"properties": {
-																	"username": {
-																		"type": "string"
-																	},
-																	"password": {
-																		"type": "string"
-																	}
-																},
-																"required": [
-																	"username",
-																	"password"
-																],
-																"additionalProperties": false
-															}
-														},
-														"required": ["image"],
-														"additionalProperties": false
-													}
-												},
-												"working_directory": {
-													"type": "string"
-												},
-												"machine": {
-													"description": "Machine must be a boolean or a map",
-													"oneOf": [
-														{
-															"description": "A boolean or a template parameter evaluating to a boolean",
-															"anyOf": [
-																{
-																	"type": "string",
-																	"pattern": " *<< *parameters.([^ ]+) *>> *"
-																},
-																{
-																	"type": "boolean"
-																},
-																{
-																	"type": "number"
-																},
-																{
-																	"type": "string"
-																}
-															]
-														},
-														{
-															"type": "object",
-															"properties": {
-																"enabled": {
-																	"description": "A boolean or a template parameter evaluating to a boolean",
-																	"anyOf": [
-																		{
-																			"type": "string",
-																			"pattern": " *<< *parameters.([^ ]+) *>> *"
-																		},
-																		{
-																			"type": "boolean"
-																		},
-																		{
-																			"type": "number"
-																		},
-																		{
-																			"type": "string"
-																		}
-																	]
-																},
-																"image": {
-																	"type": "string"
-																},
-																"docker_layer_caching": {
-																	"description": "A boolean or a template parameter evaluating to a boolean",
-																	"anyOf": [
-																		{
-																			"type": "string",
-																			"pattern": " *<< *parameters.([^ ]+) *>> *"
-																		},
-																		{
-																			"type": "boolean"
-																		},
-																		{
-																			"type": "number"
-																		},
-																		{
-																			"type": "string"
-																		}
-																	]
-																},
-																"resource_class": {
-																	"type": "string"
-																},
-																"shell": {
-																	"type": "string"
-																}
-															},
-															"additionalProperties": false
-														}
-													]
-												},
-												"environment": {
-													"oneOf": [
-														{
-															"description": "Allow null to account for empty `environment:` declarations.",
-															"type": [
-																"string",
-																"null"
-															]
-														},
-														{
-															"description": "An array of strings in the form KEY=VALUE",
-															"type": "array",
-															"items": {
-																"$ref": "#/definitions/environment"
-															}
-														},
-														{
-															"type": "object",
-															"description": "The value should be a string, but we allow null, boolean and numbers too. Examples: `FOO: true` and `BAR: 2` `BAZ:`",
-															"additionalProperties": {
-																"type": [
-																	"string",
-																	"boolean",
-																	"number",
-																	"null"
-																]
-															}
-														}
-													]
-												},
-												"shell": {
-													"oneOf": [
-														{
-															"type": "string"
-														},
-														{
-															"type": "array",
-															"items": {
-																"type": "string"
-															}
-														}
-													]
-												},
-												"parameters": {
-													"description": "Parameters given to a job.",
-													"type": "object",
-													"additionalProperties": {
-														"type": "object",
-														"properties": {
-															"type": {
-																"type": "string",
-																"enum": [
-																	"boolean",
-																	"string",
-																	"steps",
-																	"enum",
-																	"executor",
-																	"integer",
-																	"env_var_name"
-																]
-															},
-															"default": {
-																"oneOf": [
-																	{
-																		"type": "string"
-																	},
-																	{
-																		"type": "boolean"
-																	},
-																	{
-																		"type": "integer"
-																	},
-																	{
-																		"type": "array",
-																		"items": {
-																			"$ref": "#/definitions/step"
-																		}
-																	}
-																]
-															},
-															"description": {
-																"type": "string"
-															},
-															"enum": {
-																"type": "array",
-																"items": {
-																	"type": "string"
-																}
-															}
-														},
-														"additionalProperties": false,
-														"required": ["type"]
-													},
-													"minProperties": 1
-												}
-											},
-											"additionalProperties": false
-										},
-										{
-											"type": "string",
-											"description": "Executor may be a string reference to another executor"
-										}
-									]
-								}
-							},
-							"orbs": {
-								"$ref": "#/properties/orbs"
-							}
-						}
-					}
-				]
-			}
-		},
-		"commands": {
-			"type": ["object", "null"],
-			"propertyNames": {
-				"pattern": "^[a-z][a-z\\d_-]*$"
-			},
-			"additionalProperties": {
-				"oneOf": [
-					{
-						"type": "object",
-						"properties": {
-							"description": {
-								"type": "string"
-							},
-							"parameters": {
-								"description": "Parameters given to a step.",
-								"type": "object",
-								"additionalProperties": {
-									"type": "object",
-									"properties": {
-										"type": {
-											"type": "string",
-											"enum": [
-												"boolean",
-												"string",
-												"steps",
-												"enum",
-												"executor",
-												"integer",
-												"env_var_name"
-											]
-										},
-										"default": {
-											"oneOf": [
-												{
-													"type": "string"
-												},
-												{
-													"type": "boolean"
-												},
-												{
-													"type": "integer"
-												},
-												{
-													"type": "array",
-													"items": {
-														"$ref": "#/definitions/step"
-													}
-												}
-											]
-										},
-										"description": {
-											"type": "string"
-										},
-										"enum": {
-											"type": "array",
-											"items": {
-												"type": "string"
-											}
-										}
-									},
-									"additionalProperties": false,
-									"required": ["type"]
-								},
-								"minProperties": 1
-							},
-							"steps": {
-								"type": "array",
-								"items": {
-									"$ref": "#/definitions/step"
-								},
-								"minItems": 1
-							}
-						},
-						"required": ["steps"],
-						"additionalProperties": false
-					},
-					{
-						"type": "string",
-						"description": "Command may be a string reference to another command"
-					}
-				]
-			}
-		},
-		"examples": {
-			"type": "object",
-			"propertyNames": {
-				"pattern": "^[a-z][a-z\\d_-]*$"
-			},
-			"additionalProperties": {
-				"type": "object",
-				"properties": {
-					"description": {
-						"type": "string"
-					},
-					"usage": {
-						"type": "object"
-					},
-					"result": {
-						"type": "object"
-					}
-				},
-				"required": ["usage"],
-				"additionalProperties": false
-			}
-		},
-		"display": {
-			"type": "object",
-			"properties": {
-				"home_url": {
-					"type": "string"
-				},
-				"source_url": {
-					"type": "string"
-				}
-			}
-		},
-		"version": {
-			"enum": ["2.1", 2.1]
-		},
-		"parameters": {
-			"type": ["object", "null"],
-			"additionalProperties": {
-				"type": "object",
-				"properties": {
-					"type": {
-						"type": "string",
-						"enum": ["boolean", "string", "enum", "integer"]
-					},
-					"default": {
-						"oneOf": [
-							{
-								"type": "string"
-							},
-							{
-								"type": "boolean"
-							},
-							{
-								"type": "integer"
-							}
-						]
-					},
-					"description": {
-						"type": "string"
-					},
-					"enum": {
-						"type": "array",
-						"items": {
-							"type": "string"
-						}
-					}
-				},
-				"additionalProperties": false,
-				"required": ["default", "type"]
-			}
-		}
-	},
-	"required": ["version"]
+                    },
+                    {
+                        "type": "object",
+                        "properties": {
+                            "jobs": {
+                                "description": "Any string key is allowed as job name.",
+                                "type": "object",
+                                "propertyNames": {
+                                    "type": "string",
+                                    "pattern": "^[A-Za-z][A-Za-z\\s\\d_-]*$"
+                                },
+                                "additionalProperties": {
+                                    "oneOf": [
+                                        {
+                                            "title": "CircleCI Orb: Jobs",
+                                            "type": "object",
+                                            "properties": {
+                                                "description": {
+                                                    "type": "string"
+                                                },
+                                                "parallelism": {
+                                                    "description": "A integer or a parameter evaluating to a integer",
+                                                    "anyOf": [
+                                                        {
+                                                            "oneOf": [
+                                                                {
+                                                                    "type": "string",
+                                                                    "pattern": " *<< *parameters.([^ ]+) *>> *"
+                                                                },
+                                                                {
+                                                                    "type": "string",
+                                                                    "pattern": " *<< *pipeline.parameters.([^ ]+) *>> *"
+                                                                }
+                                                            ]
+                                                        },
+                                                        {
+                                                            "type": "integer"
+                                                        }
+                                                    ]
+                                                },
+                                                "macos": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "xcode": {
+                                                            "type": [
+                                                                "string",
+                                                                "number"
+                                                            ]
+                                                        },
+                                                        "resource_class": {
+                                                            "type": "string"
+                                                        },
+                                                        "shell": {
+                                                            "type": "string"
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "xcode"
+                                                    ],
+                                                    "additionalProperties": false
+                                                },
+                                                "resource_class": {
+                                                    "type": "string"
+                                                },
+                                                "docker": {
+                                                    "type": "array",
+                                                    "minItems": 1,
+                                                    "items": {
+                                                        "type": "object",
+                                                        "properties": {
+                                                            "image": {
+                                                                "type": "string"
+                                                            },
+                                                            "name": {
+                                                                "type": "string"
+                                                            },
+                                                            "entrypoint": {
+                                                                "oneOf": [
+                                                                    {
+                                                                        "type": "string"
+                                                                    },
+                                                                    {
+                                                                        "type": "array",
+                                                                        "items": {
+                                                                            "type": "string"
+                                                                        }
+                                                                    }
+                                                                ]
+                                                            },
+                                                            "command": {
+                                                                "oneOf": [
+                                                                    {
+                                                                        "type": "string"
+                                                                    },
+                                                                    {
+                                                                        "type": "array",
+                                                                        "items": {
+                                                                            "type": "string"
+                                                                        }
+                                                                    }
+                                                                ]
+                                                            },
+                                                            "user": {
+                                                                "type": "string"
+                                                            },
+                                                            "environment": {
+                                                                "oneOf": [
+                                                                    {
+                                                                        "description": "Allow null to account for empty `environment:` declarations.",
+                                                                        "type": [
+                                                                            "string",
+                                                                            "null"
+                                                                        ]
+                                                                    },
+                                                                    {
+                                                                        "description": "An array of strings in the form KEY=VALUE",
+                                                                        "type": "array",
+                                                                        "items": {
+                                                                            "$ref": "#/definitions/environment"
+                                                                        }
+                                                                    },
+                                                                    {
+                                                                        "type": "object",
+                                                                        "description": "The value should be a string, but we allow null, boolean and numbers too. Examples: `FOO: true` and `BAR: 2` `BAZ:`",
+                                                                        "additionalProperties": {
+                                                                            "type": [
+                                                                                "string",
+                                                                                "boolean",
+                                                                                "number",
+                                                                                "null"
+                                                                            ]
+                                                                        }
+                                                                    }
+                                                                ]
+                                                            },
+                                                            "aws_auth": {
+                                                                "oneOf": [
+                                                                    {
+                                                                        "type": "object",
+                                                                        "properties": {
+                                                                            "aws_access_key_id": {
+                                                                                "type": "string"
+                                                                            },
+                                                                            "aws_secret_access_key": {
+                                                                                "type": "string"
+                                                                            }
+                                                                        },
+                                                                        "required": [
+                                                                            "aws_access_key_id",
+                                                                            "aws_secret_access_key"
+                                                                        ],
+                                                                        "additionalProperties": false
+                                                                    },
+                                                                    {
+                                                                        "type": "object",
+                                                                        "properties": {
+                                                                            "oidc_role_arn": {
+                                                                                "type": "string"
+                                                                            }
+                                                                        },
+                                                                        "required": [
+                                                                            "oidc_role_arn"
+                                                                        ],
+                                                                        "additionalProperties": false
+                                                                    }
+                                                                ]
+                                                            },
+                                                            "auth": {
+                                                                "type": "object",
+                                                                "properties": {
+                                                                    "username": {
+                                                                        "type": "string"
+                                                                    },
+                                                                    "password": {
+                                                                        "type": "string"
+                                                                    }
+                                                                },
+                                                                "required": [
+                                                                    "username",
+                                                                    "password"
+                                                                ],
+                                                                "additionalProperties": false
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "image"
+                                                        ],
+                                                        "additionalProperties": false
+                                                    }
+                                                },
+                                                "steps": {
+                                                    "type": "array",
+                                                    "items": {
+                                                        "$ref": "#/definitions/step"
+                                                    },
+                                                    "minItems": 1
+                                                },
+                                                "working_directory": {
+                                                    "type": "string"
+                                                },
+                                                "circleci_ip_ranges": {
+                                                    "type": "boolean"
+                                                },
+                                                "machine": {
+                                                    "description": "Machine must be a boolean or a map",
+                                                    "oneOf": [
+                                                        {
+                                                            "description": "A boolean or a template parameter evaluating to a boolean",
+                                                            "anyOf": [
+                                                                {
+                                                                    "type": "string",
+                                                                    "pattern": " *<< *parameters.([^ ]+) *>> *"
+                                                                },
+                                                                {
+                                                                    "type": "boolean"
+                                                                },
+                                                                {
+                                                                    "type": "number"
+                                                                },
+                                                                {
+                                                                    "type": "string"
+                                                                }
+                                                            ]
+                                                        },
+                                                        {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "enabled": {
+                                                                    "description": "A boolean or a template parameter evaluating to a boolean",
+                                                                    "anyOf": [
+                                                                        {
+                                                                            "type": "string",
+                                                                            "pattern": " *<< *parameters.([^ ]+) *>> *"
+                                                                        },
+                                                                        {
+                                                                            "type": "boolean"
+                                                                        },
+                                                                        {
+                                                                            "type": "number"
+                                                                        },
+                                                                        {
+                                                                            "type": "string"
+                                                                        }
+                                                                    ]
+                                                                },
+                                                                "image": {
+                                                                    "type": "string"
+                                                                },
+                                                                "docker_layer_caching": {
+                                                                    "description": "A boolean or a template parameter evaluating to a boolean",
+                                                                    "anyOf": [
+                                                                        {
+                                                                            "type": "string",
+                                                                            "pattern": " *<< *parameters.([^ ]+) *>> *"
+                                                                        },
+                                                                        {
+                                                                            "type": "boolean"
+                                                                        },
+                                                                        {
+                                                                            "type": "number"
+                                                                        },
+                                                                        {
+                                                                            "type": "string"
+                                                                        }
+                                                                    ]
+                                                                },
+                                                                "resource_class": {
+                                                                    "type": "string"
+                                                                },
+                                                                "shell": {
+                                                                    "type": "string"
+                                                                }
+                                                            },
+                                                            "additionalProperties": false
+                                                        }
+                                                    ]
+                                                },
+                                                "environment": {
+                                                    "oneOf": [
+                                                        {
+                                                            "description": "Allow null to account for empty `environment:` declarations.",
+                                                            "type": [
+                                                                "string",
+                                                                "null"
+                                                            ]
+                                                        },
+                                                        {
+                                                            "description": "An array of strings in the form KEY=VALUE",
+                                                            "type": "array",
+                                                            "items": {
+                                                                "$ref": "#/definitions/environment"
+                                                            }
+                                                        },
+                                                        {
+                                                            "type": "object",
+                                                            "description": "The value should be a string, but we allow null, boolean and numbers too. Examples: `FOO: true` and `BAR: 2` `BAZ:`",
+                                                            "additionalProperties": {
+                                                                "type": [
+                                                                    "string",
+                                                                    "boolean",
+                                                                    "number",
+                                                                    "null"
+                                                                ]
+                                                            }
+                                                        }
+                                                    ]
+                                                },
+                                                "executor": {
+                                                    "oneOf": [
+                                                        {
+                                                            "type": "string",
+                                                            "description": "short executor invocation, name of executor"
+                                                        },
+                                                        {
+                                                            "type": "object",
+                                                            "description": "executor invocation with arguments, i.e. parameters",
+                                                            "minProperties": 1,
+                                                            "additionalProperties": true,
+                                                            "properties": {
+                                                                "name": {
+                                                                    "type": "string"
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "name"
+                                                            ]
+                                                        }
+                                                    ]
+                                                },
+                                                "shell": {
+                                                    "oneOf": [
+                                                        {
+                                                            "type": "string"
+                                                        },
+                                                        {
+                                                            "type": "array",
+                                                            "items": {
+                                                                "type": "string"
+                                                            }
+                                                        }
+                                                    ]
+                                                },
+                                                "parameters": {
+                                                    "description": "Parameters given to a job.",
+                                                    "type": "object",
+                                                    "additionalProperties": {
+                                                        "type": "object",
+                                                        "properties": {
+                                                            "type": {
+                                                                "type": "string",
+                                                                "enum": [
+                                                                    "boolean",
+                                                                    "string",
+                                                                    "steps",
+                                                                    "enum",
+                                                                    "executor",
+                                                                    "integer",
+                                                                    "env_var_name"
+                                                                ]
+                                                            },
+                                                            "default": {
+                                                                "oneOf": [
+                                                                    {
+                                                                        "type": "string"
+                                                                    },
+                                                                    {
+                                                                        "type": "boolean"
+                                                                    },
+                                                                    {
+                                                                        "type": "integer"
+                                                                    },
+                                                                    {
+                                                                        "type": "array",
+                                                                        "items": {
+                                                                            "$ref": "#/definitions/step"
+                                                                        }
+                                                                    }
+                                                                ]
+                                                            },
+                                                            "description": {
+                                                                "type": "string"
+                                                            },
+                                                            "enum": {
+                                                                "type": "array",
+                                                                "items": {
+                                                                    "type": "string"
+                                                                }
+                                                            }
+                                                        },
+                                                        "additionalProperties": false,
+                                                        "required": [
+                                                            "type"
+                                                        ]
+                                                    },
+                                                    "minProperties": 1
+                                                }
+                                            },
+                                            "required": [
+                                                "steps"
+                                            ],
+                                            "additionalProperties": false,
+                                            "anyOf": [
+                                                {
+                                                    "description": "A job must have one of `docker`, `machine`, `macos` or `executor` (which can provide docker/machine/macos information).",
+                                                    "type": "object",
+                                                    "required": [
+                                                        "executor"
+                                                    ]
+                                                },
+                                                {
+                                                    "oneOf": [
+                                                        {
+                                                            "type": "object",
+                                                            "required": [
+                                                                "machine"
+                                                            ]
+                                                        },
+                                                        {
+                                                            "type": "object",
+                                                            "required": [
+                                                                "docker"
+                                                            ]
+                                                        },
+                                                        {
+                                                            "type": "object",
+                                                            "required": [
+                                                                "macos"
+                                                            ]
+                                                        }
+                                                    ]
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "type": "string",
+                                            "description": "Job may be a string reference to another job"
+                                        }
+                                    ]
+                                }
+                            },
+                            "commands": {
+                                "type": "object",
+                                "propertyNames": {
+                                    "pattern": "^[a-z][a-z\\d_-]*$"
+                                },
+                                "additionalProperties": {
+                                    "oneOf": [
+                                        {
+                                            "type": "object",
+                                            "properties": {
+                                                "description": {
+                                                    "type": "string"
+                                                },
+                                                "parameters": {
+                                                    "description": "Parameters given to a step.",
+                                                    "type": "object",
+                                                    "additionalProperties": {
+                                                        "type": "object",
+                                                        "properties": {
+                                                            "type": {
+                                                                "type": "string",
+                                                                "enum": [
+                                                                    "boolean",
+                                                                    "string",
+                                                                    "steps",
+                                                                    "enum",
+                                                                    "executor",
+                                                                    "integer",
+                                                                    "env_var_name"
+                                                                ]
+                                                            },
+                                                            "default": {
+                                                                "oneOf": [
+                                                                    {
+                                                                        "type": "string"
+                                                                    },
+                                                                    {
+                                                                        "type": "boolean"
+                                                                    },
+                                                                    {
+                                                                        "type": "integer"
+                                                                    },
+                                                                    {
+                                                                        "type": "array",
+                                                                        "items": {
+                                                                            "$ref": "#/definitions/step"
+                                                                        }
+                                                                    }
+                                                                ]
+                                                            },
+                                                            "description": {
+                                                                "type": "string"
+                                                            },
+                                                            "enum": {
+                                                                "type": "array",
+                                                                "items": {
+                                                                    "type": "string"
+                                                                }
+                                                            }
+                                                        },
+                                                        "additionalProperties": false,
+                                                        "required": [
+                                                            "type"
+                                                        ]
+                                                    },
+                                                    "minProperties": 1
+                                                },
+                                                "steps": {
+                                                    "type": "array",
+                                                    "items": {
+                                                        "$ref": "#/definitions/step"
+                                                    },
+                                                    "minItems": 1
+                                                }
+                                            },
+                                            "required": [
+                                                "steps"
+                                            ],
+                                            "additionalProperties": false
+                                        },
+                                        {
+                                            "type": "string",
+                                            "description": "Command may be a string reference to another command"
+                                        }
+                                    ]
+                                }
+                            },
+                            "executors": {
+                                "type": "object",
+                                "propertyNames": {
+                                    "pattern": "^[a-z][a-z\\d_-]*$"
+                                },
+                                "additionalProperties": {
+                                    "oneOf": [
+                                        {
+                                            "type": "object",
+                                            "properties": {
+                                                "description": {
+                                                    "type": "string"
+                                                },
+                                                "macos": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "xcode": {
+                                                            "type": [
+                                                                "string",
+                                                                "number"
+                                                            ]
+                                                        },
+                                                        "resource_class": {
+                                                            "type": "string"
+                                                        },
+                                                        "shell": {
+                                                            "type": "string"
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "xcode"
+                                                    ],
+                                                    "additionalProperties": false
+                                                },
+                                                "resource_class": {
+                                                    "type": "string"
+                                                },
+                                                "docker": {
+                                                    "type": "array",
+                                                    "minItems": 1,
+                                                    "items": {
+                                                        "type": "object",
+                                                        "properties": {
+                                                            "image": {
+                                                                "type": "string"
+                                                            },
+                                                            "name": {
+                                                                "type": "string"
+                                                            },
+                                                            "entrypoint": {
+                                                                "oneOf": [
+                                                                    {
+                                                                        "type": "string"
+                                                                    },
+                                                                    {
+                                                                        "type": "array",
+                                                                        "items": {
+                                                                            "type": "string"
+                                                                        }
+                                                                    }
+                                                                ]
+                                                            },
+                                                            "command": {
+                                                                "oneOf": [
+                                                                    {
+                                                                        "type": "string"
+                                                                    },
+                                                                    {
+                                                                        "type": "array",
+                                                                        "items": {
+                                                                            "type": "string"
+                                                                        }
+                                                                    }
+                                                                ]
+                                                            },
+                                                            "user": {
+                                                                "type": "string"
+                                                            },
+                                                            "environment": {
+                                                                "oneOf": [
+                                                                    {
+                                                                        "description": "Allow null to account for empty `environment:` declarations.",
+                                                                        "type": [
+                                                                            "string",
+                                                                            "null"
+                                                                        ]
+                                                                    },
+                                                                    {
+                                                                        "description": "An array of strings in the form KEY=VALUE",
+                                                                        "type": "array",
+                                                                        "items": {
+                                                                            "$ref": "#/definitions/environment"
+                                                                        }
+                                                                    },
+                                                                    {
+                                                                        "type": "object",
+                                                                        "description": "The value should be a string, but we allow null, boolean and numbers too. Examples: `FOO: true` and `BAR: 2` `BAZ:`",
+                                                                        "additionalProperties": {
+                                                                            "type": [
+                                                                                "string",
+                                                                                "boolean",
+                                                                                "number",
+                                                                                "null"
+                                                                            ]
+                                                                        }
+                                                                    }
+                                                                ]
+                                                            },
+                                                            "aws_auth": {
+                                                                "oneOf": [
+                                                                    {
+                                                                        "type": "object",
+                                                                        "properties": {
+                                                                            "aws_access_key_id": {
+                                                                                "type": "string"
+                                                                            },
+                                                                            "aws_secret_access_key": {
+                                                                                "type": "string"
+                                                                            }
+                                                                        },
+                                                                        "required": [
+                                                                            "aws_access_key_id",
+                                                                            "aws_secret_access_key"
+                                                                        ],
+                                                                        "additionalProperties": false
+                                                                    },
+                                                                    {
+                                                                        "type": "object",
+                                                                        "properties": {
+                                                                            "oidc_role_arn": {
+                                                                                "type": "string"
+                                                                            }
+                                                                        },
+                                                                        "required": [
+                                                                            "oidc_role_arn"
+                                                                        ],
+                                                                        "additionalProperties": false
+                                                                    }
+                                                                ]
+                                                            },
+                                                            "auth": {
+                                                                "type": "object",
+                                                                "properties": {
+                                                                    "username": {
+                                                                        "type": "string"
+                                                                    },
+                                                                    "password": {
+                                                                        "type": "string"
+                                                                    }
+                                                                },
+                                                                "required": [
+                                                                    "username",
+                                                                    "password"
+                                                                ],
+                                                                "additionalProperties": false
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "image"
+                                                        ],
+                                                        "additionalProperties": false
+                                                    }
+                                                },
+                                                "working_directory": {
+                                                    "type": "string"
+                                                },
+                                                "machine": {
+                                                    "description": "Machine must be a boolean or a map",
+                                                    "oneOf": [
+                                                        {
+                                                            "description": "A boolean or a template parameter evaluating to a boolean",
+                                                            "anyOf": [
+                                                                {
+                                                                    "type": "string",
+                                                                    "pattern": " *<< *parameters.([^ ]+) *>> *"
+                                                                },
+                                                                {
+                                                                    "type": "boolean"
+                                                                },
+                                                                {
+                                                                    "type": "number"
+                                                                },
+                                                                {
+                                                                    "type": "string"
+                                                                }
+                                                            ]
+                                                        },
+                                                        {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "enabled": {
+                                                                    "description": "A boolean or a template parameter evaluating to a boolean",
+                                                                    "anyOf": [
+                                                                        {
+                                                                            "type": "string",
+                                                                            "pattern": " *<< *parameters.([^ ]+) *>> *"
+                                                                        },
+                                                                        {
+                                                                            "type": "boolean"
+                                                                        },
+                                                                        {
+                                                                            "type": "number"
+                                                                        },
+                                                                        {
+                                                                            "type": "string"
+                                                                        }
+                                                                    ]
+                                                                },
+                                                                "image": {
+                                                                    "type": "string"
+                                                                },
+                                                                "docker_layer_caching": {
+                                                                    "description": "A boolean or a template parameter evaluating to a boolean",
+                                                                    "anyOf": [
+                                                                        {
+                                                                            "type": "string",
+                                                                            "pattern": " *<< *parameters.([^ ]+) *>> *"
+                                                                        },
+                                                                        {
+                                                                            "type": "boolean"
+                                                                        },
+                                                                        {
+                                                                            "type": "number"
+                                                                        },
+                                                                        {
+                                                                            "type": "string"
+                                                                        }
+                                                                    ]
+                                                                },
+                                                                "resource_class": {
+                                                                    "type": "string"
+                                                                },
+                                                                "shell": {
+                                                                    "type": "string"
+                                                                }
+                                                            },
+                                                            "additionalProperties": false
+                                                        }
+                                                    ]
+                                                },
+                                                "environment": {
+                                                    "oneOf": [
+                                                        {
+                                                            "description": "Allow null to account for empty `environment:` declarations.",
+                                                            "type": [
+                                                                "string",
+                                                                "null"
+                                                            ]
+                                                        },
+                                                        {
+                                                            "description": "An array of strings in the form KEY=VALUE",
+                                                            "type": "array",
+                                                            "items": {
+                                                                "$ref": "#/definitions/environment"
+                                                            }
+                                                        },
+                                                        {
+                                                            "type": "object",
+                                                            "description": "The value should be a string, but we allow null, boolean and numbers too. Examples: `FOO: true` and `BAR: 2` `BAZ:`",
+                                                            "additionalProperties": {
+                                                                "type": [
+                                                                    "string",
+                                                                    "boolean",
+                                                                    "number",
+                                                                    "null"
+                                                                ]
+                                                            }
+                                                        }
+                                                    ]
+                                                },
+                                                "shell": {
+                                                    "oneOf": [
+                                                        {
+                                                            "type": "string"
+                                                        },
+                                                        {
+                                                            "type": "array",
+                                                            "items": {
+                                                                "type": "string"
+                                                            }
+                                                        }
+                                                    ]
+                                                },
+                                                "parameters": {
+                                                    "description": "Parameters given to a job.",
+                                                    "type": "object",
+                                                    "additionalProperties": {
+                                                        "type": "object",
+                                                        "properties": {
+                                                            "type": {
+                                                                "type": "string",
+                                                                "enum": [
+                                                                    "boolean",
+                                                                    "string",
+                                                                    "steps",
+                                                                    "enum",
+                                                                    "executor",
+                                                                    "integer",
+                                                                    "env_var_name"
+                                                                ]
+                                                            },
+                                                            "default": {
+                                                                "oneOf": [
+                                                                    {
+                                                                        "type": "string"
+                                                                    },
+                                                                    {
+                                                                        "type": "boolean"
+                                                                    },
+                                                                    {
+                                                                        "type": "integer"
+                                                                    },
+                                                                    {
+                                                                        "type": "array",
+                                                                        "items": {
+                                                                            "$ref": "#/definitions/step"
+                                                                        }
+                                                                    }
+                                                                ]
+                                                            },
+                                                            "description": {
+                                                                "type": "string"
+                                                            },
+                                                            "enum": {
+                                                                "type": "array",
+                                                                "items": {
+                                                                    "type": "string"
+                                                                }
+                                                            }
+                                                        },
+                                                        "additionalProperties": false,
+                                                        "required": [
+                                                            "type"
+                                                        ]
+                                                    },
+                                                    "minProperties": 1
+                                                }
+                                            },
+                                            "additionalProperties": false
+                                        },
+                                        {
+                                            "type": "string",
+                                            "description": "Executor may be a string reference to another executor"
+                                        }
+                                    ]
+                                }
+                            },
+                            "orbs": {
+                                "$ref": "#/properties/orbs"
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        "commands": {
+            "type": [
+                "object",
+                "null"
+            ],
+            "propertyNames": {
+                "pattern": "^[a-z][a-z\\d_-]*$"
+            },
+            "additionalProperties": {
+                "oneOf": [
+                    {
+                        "type": "object",
+                        "properties": {
+                            "description": {
+                                "type": "string"
+                            },
+                            "parameters": {
+                                "description": "Parameters given to a step.",
+                                "type": "object",
+                                "additionalProperties": {
+                                    "type": "object",
+                                    "properties": {
+                                        "type": {
+                                            "type": "string",
+                                            "enum": [
+                                                "boolean",
+                                                "string",
+                                                "steps",
+                                                "enum",
+                                                "executor",
+                                                "integer",
+                                                "env_var_name"
+                                            ]
+                                        },
+                                        "default": {
+                                            "oneOf": [
+                                                {
+                                                    "type": "string"
+                                                },
+                                                {
+                                                    "type": "boolean"
+                                                },
+                                                {
+                                                    "type": "integer"
+                                                },
+                                                {
+                                                    "type": "array",
+                                                    "items": {
+                                                        "$ref": "#/definitions/step"
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        "description": {
+                                            "type": "string"
+                                        },
+                                        "enum": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    },
+                                    "additionalProperties": false,
+                                    "required": [
+                                        "type"
+                                    ]
+                                },
+                                "minProperties": 1
+                            },
+                            "steps": {
+                                "type": "array",
+                                "items": {
+                                    "$ref": "#/definitions/step"
+                                },
+                                "minItems": 1
+                            }
+                        },
+                        "required": [
+                            "steps"
+                        ],
+                        "additionalProperties": false
+                    },
+                    {
+                        "type": "string",
+                        "description": "Command may be a string reference to another command"
+                    }
+                ]
+            }
+        },
+        "examples": {
+            "type": "object",
+            "propertyNames": {
+                "pattern": "^[a-z][a-z\\d_-]*$"
+            },
+            "additionalProperties": {
+                "type": "object",
+                "properties": {
+                    "description": {
+                        "type": "string"
+                    },
+                    "usage": {
+                        "type": "object"
+                    },
+                    "result": {
+                        "type": "object"
+                    }
+                },
+                "required": [
+                    "usage"
+                ],
+                "additionalProperties": false
+            }
+        },
+        "display": {
+            "type": "object",
+            "properties": {
+                "home_url": {
+                    "type": "string"
+                },
+                "source_url": {
+                    "type": "string"
+                }
+            }
+        },
+        "version": {
+            "enum": [
+                "2.1",
+                2.1
+            ]
+        },
+        "parameters": {
+            "type": [
+                "object",
+                "null"
+            ],
+            "additionalProperties": {
+                "type": "object",
+                "properties": {
+                    "type": {
+                        "type": "string",
+                        "enum": [
+                            "boolean",
+                            "string",
+                            "enum",
+                            "integer"
+                        ]
+                    },
+                    "default": {
+                        "oneOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "boolean"
+                            },
+                            {
+                                "type": "integer"
+                            }
+                        ]
+                    },
+                    "description": {
+                        "type": "string"
+                    },
+                    "enum": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "additionalProperties": false,
+                "required": [
+                    "default",
+                    "type"
+                ]
+            }
+        }
+    },
+    "required": [
+        "version"
+    ]
 }


### PR DESCRIPTION
Jira: https://circleci.atlassian.net/browse/PIPE-5266

# Description

## New job types
This PR adds support for two job types:

- `lock`
- `unlock`

## Improved schema validation
While these job types are not explicitly explained in the docs, they are the underling job types that our [serial group](https://circleci.com/docs/guides/orchestrate/controlling-serial-execution-across-your-organization/) feature uses under the hood.

This MR also also adds improved validations for other job types that we already had:

- `approval` / `no-op` jobs don't need any additional parameters to be valid
- `lock` / `unlock` require a `key: ` parameter to be specified
    ```yml
    my-cool-lock-job:
      type: lock
    ```
    - <img width="585" height="361" alt="image" src="https://github.com/user-attachments/assets/d9d664dc-c9f2-4b39-8928-07556cc9eca5" />

- `release` jobs require a `plan_name:` parameter to be specified
    ```yml
    my-cool-release-job:
      type: release
    ```
    - <img width="585" height="361" alt="image" src="https://github.com/user-attachments/assets/7439532c-bebe-49b1-9410-17228a0f9b63" />

## Other changes
- adding plan_name and key to the parser, AST, and completions
- added job types to completions in the Go code (control + space in vscode should now give you a list of job types, YMMV is seems to work intermittently)
    <img width="684" height="316" alt="image" src="https://github.com/user-attachments/assets/488ba810-bc16-4322-bb1a-2cc4abd60b98" />
- added some more documentation to `HACKING.md` to explain the difference between our schemas and when to update which one

# Implementation details

To improve the experience of editing these schema.json files, I ran the default vscode JSON auto-formatter with 4 spaces on the `schema` and `publicschema` files. This makes the diff hard to read, so [this commit is where I actually add the new re-usable jobDefinition with all the new validations.](https://github.com/CircleCI-Public/circleci-yaml-language-server/commit/24d51a3ce0a83b8743a9b37e090ad67281046e64) I re-use this jobDefinition ref inside the jobs: section and the orbs: jobs: section. 

In order to add the complex JSON schema rules, I needed to use if/then/else syntax which was introduced in JSON schema draft-07. I bumped the version of `schema.json`.

# How to validate

Following the steps in `HACKING.md` to run the language server extension in VScode would be the easiest way to verify it works in your editor!

