### PR TITLE
feat: Add new 2025 Q3 Android image

### DIFF
--- a/pkg/utils/executors.go
+++ b/pkg/utils/executors.go
@@ -66,6 +66,7 @@ var ValidLinuxImages = []string{
 	"ubuntu-2404:edge",
 
 	// Android
+	"android:2025.10.1",
 	"android:2024.11.1",
 	"android:2024.04.1",
 	"android:2024.01.1",


### PR DESCRIPTION
# Description

This PR adds a new Android image for 2025 Q3
- https://circleci.com/developer/machine/image/android

# Implementation details
Added new image to existing array of images for Q3 2025 release cycle

# How to validate
Here's a quick usage example with "Hello World" configuration:
```yaml
version: 2.1
jobs:
  build:
    machine:
      image: 'android:2025.10.1'
      resource_class: medium
    steps:
      - run: echo 'Hello World'
      - run: |
          echo "Hello World from Android 2025 Q3!"
```