### PR TITLE
feat: Add new 2025 Q3 Windows Images

### DIFF
--- a/pkg/utils/executors.go
+++ b/pkg/utils/executors.go
@@ -125,7 +125,8 @@ var ValidWindowsImages = []string{
 	"windows-server-2019-vs2019:edge",
 
 	// Windows Server 2022
-	"windows-server-2022:2024.12.1",
+	"windows-server-2022-gui:2025.10.1",
+	"windows-server-2022-gui:2024.12.1",
 	"windows-server-2022-gui:2024.04.1",
 	"windows-server-2022-gui:2024.01.1",
 	"windows-server-2022-gui:2023.11.1",
@@ -143,6 +144,11 @@ var ValidWindowsImages = []string{
 	"windows-server-2022-gui:2022.04.1",
 	"windows-server-2022-gui:current",
 	"windows-server-2022-gui:edge",
+
+	// Windows Server 2025
+	"windows-server-2025-gui:2025.10.1",
+	// "windows-server-2025-gui:current",
+	"windows-server-2025-gui:edge",
 }
 
 var ValidWindowsResourceClasses = []string{
@@ -179,6 +185,8 @@ var ValidWindowsGPUImages = []string{
 	"windows-server-2019-cuda:edge",
 	"windows-server-2022-cuda:current",
 	"windows-server-2022-cuda:edge",
+	// "windows-server-2025-cuda:current",
+	"windows-server-2025-cuda:edge",
 }
 
 var ValidWindowsGPUResourceClasses = []string{


### PR DESCRIPTION
# Description

This PR adds a new Windows images for 2025 Q3.
- https://circleci.com/developer/machine/image/windows-server-2022-gui as well as others

**Note: the current images are currently commented out since they don't exist yet**

# Implementation details
Added new images to existing array of images for Q3 2025 release cycle

# How to validate
Here's a quick usage example with "Hello World" configuration:
```yaml
version: 2.1
jobs:
  build:
    machine:
      image: 'windows-server-2022-gui:2025.10.1'
      resource_class: medium
    steps:
      - run: echo 'Hello World'
      - run: |
          echo "Hello World from Android 2025 Q3!"
```

***Note: previously there was a mislabeled image as `windows-server-2022:2024.12.1` instead of `windows-server-2022:2024.12.1` that got fixed.