### PR TITLE
fix: print on stderr to avoid violating LSP in stdio mode

### DIFF
--- a/pkg/parser/jsonschema.go
+++ b/pkg/parser/jsonschema.go
@@ -2,6 +2,7 @@ package parser
 
 import (
 	"fmt"
+	"os"
 	"regexp"
 	"strconv"
 	"strings"
@@ -25,8 +26,8 @@ func (validator *JSONSchemaValidator) LoadJsonSchema(schemaLocation string) erro
 
 	schema, err := gojsonschema.NewSchema(loader)
 	if err != nil {
-		fmt.Printf("Error while loading JSON Schema \"%s\"\n", schemaLocation)
-		fmt.Println(err.Error())
+		fmt.Fprintf(os.Stderr, "Error while loading JSON Schema \"%s\"\n", schemaLocation)
+		fmt.Fprintln(os.Stderr, err.Error())
 		return err
 	}
 

--- a/pkg/parser/remoteOrb.go
+++ b/pkg/parser/remoteOrb.go
@@ -267,7 +267,7 @@ func writeRemoteOrbSourceInFSCache(orbYaml string, source string) (string, error
 	_, err := os.Stat(filePath)
 
 	if errors.Is(err, os.ErrNotExist) {
-		fmt.Println("Writing remote orb source in cache:", filePath)
+		fmt.Fprintln(os.Stderr, "Writing remote orb source in cache:", filePath)
 
 		err = os.WriteFile(filePath, []byte(source), 0644)
 		return filePath, err

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -26,7 +26,7 @@ type JSONRPCServer struct {
 }
 
 func (server JSONRPCServer) commandHandler(_ context.Context, reply jsonrpc2.Replier, req jsonrpc2.Request) error {
-	fmt.Println("Called method: " + req.Method())
+	fmt.Fprintln(os.Stderr, "Called method: "+req.Method())
 
 	defer func() {
 		err := recover()
@@ -89,7 +89,7 @@ func (server JSONRPCServer) commandHandler(_ context.Context, reply jsonrpc2.Rep
 
 func (server JSONRPCServer) ServeStream(_ context.Context, conn jsonrpc2.Conn) error {
 	defer rollbar.Close()
-	fmt.Println("New client connection")
+	fmt.Fprintln(os.Stderr, "New client connection")
 
 	server.conn = conn
 	server.cache = utils.CreateCache()

--- a/pkg/services/definition/definition.go
+++ b/pkg/services/definition/definition.go
@@ -2,6 +2,7 @@ package definition
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/CircleCI-Public/circleci-yaml-language-server/pkg/ast"
 	yamlparser "github.com/CircleCI-Public/circleci-yaml-language-server/pkg/parser"
@@ -54,7 +55,7 @@ func (def DefinitionStruct) Definition() ([]protocol.Location, error) {
 	}
 
 	if err != nil {
-		fmt.Println("error occurred during definition:", err)
+		fmt.Fprintln(os.Stderr, "error occurred during definition:", err)
 	}
 	return res, nil
 }


### PR DESCRIPTION
# Description

[See issue here ](https://github.com/CircleCI-Public/circleci-yaml-language-server/issues/371)

# Implementation details

Replaced our calls to stdio with stderr

# How to validate

Run the server locally with --stdio flag and ensure it still works with your editor

