### PR TITLE
feat: Add Windows server 2025 current images

### DIFF
--- a/pkg/utils/executors.go
+++ b/pkg/utils/executors.go
@@ -147,7 +147,7 @@ var ValidWindowsImages = []string{
 
 	// Windows Server 2025
 	"windows-server-2025-gui:2025.10.1",
-	// "windows-server-2025-gui:current",
+	"windows-server-2025-gui:current",
 	"windows-server-2025-gui:edge",
 }
 
@@ -185,7 +185,7 @@ var ValidWindowsGPUImages = []string{
 	"windows-server-2019-cuda:edge",
 	"windows-server-2022-cuda:current",
 	"windows-server-2022-cuda:edge",
-	// "windows-server-2025-cuda:current",
+	"windows-server-2025-cuda:current",
 	"windows-server-2025-cuda:edge",
 }
 


### PR DESCRIPTION
# Description

This PR uncomments the `windows-server-2025-gui:current` and `windows-server-2025-cuda:current` executor in the list of valid Windows executors, making it available for use in CircleCI configurations.

# How to validate

1. Install the extension in VS Code
2. Create a CircleCI config file with a job using `windows-server-2025-gui:current` and `windows-server-2025-cuda:current` executor
3. Verify that the language server recognizes it as a valid executor (no validation errors)
4. Test autocomplete functionality for the executor name"
