### PR TITLE
feat: suppress errors/warnings/diagnostics via comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,18 @@ CircleCI Configuration files. It offers:
     <img src="https://images.ctfassets.net/il1yandlcjgk/3jXaQvhOQgayhV9O4nfAhZ/b6d55e689ddfcf7673ab7e9b76ba0a53/config_helper_autocomplete.png" alt="circleci-vscode-autocomplete" width="50%"/>
 </p>
 
+- **Diagnostic suppression** - allows you to suppress specific warnings and errors using special comments:
+  - `# cci-ignore` - suppress diagnostic on the same line
+  - `# cci-ignore-next-line` - suppress diagnostic on the next line
+  - `# cci-ignore-start` / `# cci-ignore-end` - suppress diagnostics in a range
+  - `# cci-ignore-file` - suppress all diagnostics in the file
+
+  Quick-fix code actions are available to automatically insert suppression comments.
+
+<p align="center">
+    <img src="https://images.ctfassets.net/il1yandlcjgk/2HsFnWKVRDavrKYN6gns6T/f30a25920e1a0c47fc7beaa2e81b93a0/cci-ignore-next-line.gif" alt="circleci-ignore-comments" width="50%"/>
+</p>
+
 ## <a name="platforms"></a>Platforms, Deployment and Package Managers
 
 The tool is deployed through

--- a/pkg/parser/suppression.go
+++ b/pkg/parser/suppression.go
@@ -1,0 +1,148 @@
+package parser
+
+import (
+	"regexp"
+
+	"github.com/CircleCI-Public/circleci-yaml-language-server/pkg/utils"
+	sitter "github.com/smacker/go-tree-sitter"
+	"go.lsp.dev/protocol"
+)
+
+type SuppressionInfo struct {
+	FileWideSuppression bool
+	SuppressedLines     map[uint32]bool
+	SuppressedRanges    []SuppressionRange
+}
+
+type SuppressionRange struct {
+	StartLine uint32
+	EndLine   uint32
+}
+
+var (
+	ignoreFileRegex       = regexp.MustCompile(`^\s*#\s*cci-ignore-file\s*$`)
+	ignoreInlineRegex     = regexp.MustCompile(`#\s*cci-ignore\s*$`)
+	ignoreNextLineRegex   = regexp.MustCompile(`^\s*#\s*cci-ignore-next-line\s*$`)
+	ignoreRangeStartRegex = regexp.MustCompile(`^\s*#\s*cci-ignore-start\s*$`)
+	ignoreRangeEndRegex   = regexp.MustCompile(`^\s*#\s*cci-ignore-end\s*$`)
+)
+
+func ParseSuppressionComments(doc *YamlDocument) *SuppressionInfo {
+	rootNode := doc.RootNode
+	suppressionInfo := &SuppressionInfo{
+		FileWideSuppression: false,
+		SuppressedLines:     make(map[uint32]bool),
+		SuppressedRanges:    []SuppressionRange{},
+	}
+
+	isRangeOpen := false
+	suppressionRange := SuppressionRange{}
+
+	// fetch all comments via tree-sitter and build up the suppression info
+	ExecQuery(rootNode, "(comment) @comment", func(match *sitter.QueryMatch) {
+		for _, capture := range match.Captures {
+			node := capture.Node
+			commentText := doc.GetNodeText(node)
+
+			// cci-ignore-file
+			if ignoreFileRegex.MatchString(commentText) {
+				suppressionInfo.FileWideSuppression = true
+				return
+			}
+
+			// cci-ignore
+			if ignoreInlineRegex.MatchString(commentText) {
+				line := doc.NodeToRange(node).Start.Line
+				suppressionInfo.SuppressedLines[line] = true
+			}
+
+			// cci-ignore-next-line
+			if ignoreNextLineRegex.MatchString(commentText) {
+				line := doc.NodeToRange(node).Start.Line
+				suppressionInfo.SuppressedLines[line+1] = true
+			}
+
+			// cci-ignore-start
+			if ignoreRangeStartRegex.MatchString(commentText) {
+				if isRangeOpen {
+					diagnostic := utils.CreateErrorDiagnosticFromNode(node, "cci-ignore-start must have a closing cci-ignore-end before trying to open a new ignore-range")
+					doc.addDiagnostic(diagnostic)
+					return
+				}
+				isRangeOpen = true
+				suppressionRange.StartLine = doc.NodeToRange(node).Start.Line
+			}
+
+			// cci-ignore-end
+			if ignoreRangeEndRegex.MatchString(commentText) {
+				if !isRangeOpen {
+					diagnostic := utils.CreateErrorDiagnosticFromNode(node, "cci-ignore-end must have an opening cci-ignore-start")
+					doc.addDiagnostic(diagnostic)
+					return
+				}
+				isRangeOpen = false
+				suppressionRange.EndLine = doc.NodeToRange(node).Start.Line
+				suppressionInfo.SuppressedRanges = append(suppressionInfo.SuppressedRanges, suppressionRange)
+			}
+		}
+	})
+
+	// Check if a range was left open without closing
+	if isRangeOpen {
+		// Create diagnostic at the cci-ignore-start line
+		diagnostic := protocol.Diagnostic{
+			Range: protocol.Range{
+				Start: protocol.Position{Line: suppressionRange.StartLine, Character: 0},
+				End:   protocol.Position{Line: suppressionRange.StartLine, Character: 100},
+			},
+			Severity: protocol.DiagnosticSeverityError,
+			Source:   "circleci",
+			Message:  "cci-ignore-start is missing a closing cci-ignore-end",
+		}
+		doc.addDiagnostic(diagnostic)
+	}
+
+	return suppressionInfo
+}
+
+// isDiagnosticSuppressed returns true if the diagnostic is suppressed by any one of the cci-ignore comments in the file
+func isDiagnosticSuppressed(suppressionInfo *SuppressionInfo, diagnostic protocol.Diagnostic) bool {
+	if suppressionInfo == nil {
+		return false
+	}
+
+	if suppressionInfo.FileWideSuppression {
+		return true
+	}
+
+	// NOTE: for a multi-line diagnostic, having `# cci-ignore-next-line` before it would ignore the whole diagnostic
+	if suppressionInfo.SuppressedLines[diagnostic.Range.Start.Line] {
+		return true
+	}
+
+	for _, suppressionRange := range suppressionInfo.SuppressedRanges {
+		if diagnosticOverlapsRange(suppressionRange, diagnostic) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// diagnosticOverlapsRange returns true if the diagnostic's line range overlaps with the cci-ignore suppression range
+func diagnosticOverlapsRange(r SuppressionRange, diagnostic protocol.Diagnostic) bool {
+	return r.StartLine <= diagnostic.Range.Start.Line && r.EndLine >= diagnostic.Range.Start.Line
+}
+
+// FilterSuppressedDiagnostics returns a new slice of diagnostics that are not suppressed by any of the cci-ignore comments in the file
+func FilterSuppressedDiagnostics(diagnostics []protocol.Diagnostic, suppression *SuppressionInfo) []protocol.Diagnostic {
+	remainingDiagnostics := []protocol.Diagnostic{}
+
+	for _, diagnostic := range diagnostics {
+		if !isDiagnosticSuppressed(suppression, diagnostic) {
+			remainingDiagnostics = append(remainingDiagnostics, diagnostic)
+		}
+	}
+
+	return remainingDiagnostics
+}

--- a/pkg/parser/suppression_test.go
+++ b/pkg/parser/suppression_test.go
@@ -1,0 +1,556 @@
+package parser
+
+import (
+	"testing"
+
+	"github.com/CircleCI-Public/circleci-yaml-language-server/pkg/utils"
+	"go.lsp.dev/protocol"
+)
+
+func TestParseSuppressionComments(t *testing.T) {
+	tests := []struct {
+		name                    string
+		yaml                    string
+		wantFileWideSuppression bool
+		wantSuppressedLines     map[uint32]bool
+		wantSuppressedRanges    []SuppressionRange
+		wantDiagnosticsCount    int
+	}{
+		{
+			name: "File-wide suppression",
+			yaml: `# cci-ignore-file
+version: 2.1
+jobs:
+  test:
+    docker:
+      - image: invalid`,
+			wantFileWideSuppression: true,
+			wantSuppressedLines:     map[uint32]bool{},
+			wantSuppressedRanges:    []SuppressionRange{},
+			wantDiagnosticsCount:    0,
+		},
+		{
+			name: "Inline suppression",
+			yaml: `version: 2.1
+jobs:
+  test: # cci-ignore
+    docker:
+      - image: foo`,
+			wantFileWideSuppression: false,
+			wantSuppressedLines:     map[uint32]bool{2: true},
+			wantSuppressedRanges:    []SuppressionRange{},
+			wantDiagnosticsCount:    0,
+		},
+		{
+			name: "Next-line suppression",
+			yaml: `version: 2.1
+jobs:
+  test:
+    docker:
+      # cci-ignore-next-line
+      - image: foo`,
+			wantFileWideSuppression: false,
+			wantSuppressedLines:     map[uint32]bool{5: true},
+			wantSuppressedRanges:    []SuppressionRange{},
+			wantDiagnosticsCount:    0,
+		},
+		{
+			name: "Range suppression",
+			yaml: `version: 2.1
+jobs:
+  # cci-ignore-start
+  test:
+    docker:
+      - image: foo
+  # cci-ignore-end
+  another:
+    docker:
+      - image: bar`,
+			wantFileWideSuppression: false,
+			wantSuppressedLines:     map[uint32]bool{},
+			wantSuppressedRanges: []SuppressionRange{
+				{StartLine: 2, EndLine: 6},
+			},
+			wantDiagnosticsCount: 0,
+		},
+		{
+			name: "Multiple range suppressions",
+			yaml: `version: 2.1
+# cci-ignore-start
+jobs:
+  test:
+# cci-ignore-end
+    docker:
+      - image: foo
+# cci-ignore-start
+  another:
+    docker:
+# cci-ignore-end
+      - image: bar`,
+			wantFileWideSuppression: false,
+			wantSuppressedLines:     map[uint32]bool{},
+			wantSuppressedRanges: []SuppressionRange{
+				{StartLine: 1, EndLine: 4},
+				{StartLine: 7, EndLine: 10},
+			},
+			wantDiagnosticsCount: 0,
+		},
+		{
+			name: "Unclosed range suppression",
+			yaml: `version: 2.1
+# cci-ignore-start
+jobs:
+  test:
+    docker:
+      - image: foo`,
+			wantFileWideSuppression: false,
+			wantSuppressedLines:     map[uint32]bool{},
+			wantSuppressedRanges:    []SuppressionRange{},
+			wantDiagnosticsCount:    1,
+		},
+		{
+			name: "Range end without start",
+			yaml: `version: 2.1
+jobs:
+  test:
+    # cci-ignore-end
+    docker:
+      - image: foo`,
+			wantFileWideSuppression: false,
+			wantSuppressedLines:     map[uint32]bool{},
+			wantSuppressedRanges:    []SuppressionRange{},
+			wantDiagnosticsCount:    1,
+		},
+		{
+			name: "Nested range start (error)",
+			yaml: `version: 2.1
+# cci-ignore-start
+jobs:
+  # cci-ignore-start
+  test:
+    docker:
+# cci-ignore-end
+      - image: foo`,
+			wantFileWideSuppression: false,
+			wantSuppressedLines:     map[uint32]bool{},
+			wantSuppressedRanges: []SuppressionRange{
+				{StartLine: 1, EndLine: 6},
+			},
+			wantDiagnosticsCount: 1,
+		},
+		{
+			name: "Multiple suppression types",
+			yaml: `version: 2.1
+# cci-ignore-start
+jobs:
+  test: # cci-ignore
+# cci-ignore-end
+    docker:
+      # cci-ignore-next-line
+      - image: foo`,
+			wantFileWideSuppression: false,
+			wantSuppressedLines:     map[uint32]bool{3: true, 7: true},
+			wantSuppressedRanges: []SuppressionRange{
+				{StartLine: 1, EndLine: 4},
+			},
+			wantDiagnosticsCount: 0,
+		},
+		{
+			name: "No suppressions",
+			yaml: `version: 2.1
+jobs:
+  test:
+    docker:
+      - image: foo`,
+			wantFileWideSuppression: false,
+			wantSuppressedLines:     map[uint32]bool{},
+			wantSuppressedRanges:    []SuppressionRange{},
+			wantDiagnosticsCount:    0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			doc := ParseFile([]byte(tt.yaml), &utils.LsContext{})
+			suppressionInfo := ParseSuppressionComments(&doc)
+
+			if suppressionInfo.FileWideSuppression != tt.wantFileWideSuppression {
+				t.Errorf("FileWideSuppression = %v, want %v", suppressionInfo.FileWideSuppression, tt.wantFileWideSuppression)
+			}
+
+			if len(suppressionInfo.SuppressedLines) != len(tt.wantSuppressedLines) {
+				t.Errorf("SuppressedLines count = %v, want %v", len(suppressionInfo.SuppressedLines), len(tt.wantSuppressedLines))
+			}
+
+			for line := range tt.wantSuppressedLines {
+				if !suppressionInfo.SuppressedLines[line] {
+					t.Errorf("Expected line %d to be suppressed", line)
+				}
+			}
+
+			if len(suppressionInfo.SuppressedRanges) != len(tt.wantSuppressedRanges) {
+				t.Errorf("SuppressedRanges count = %v, want %v", len(suppressionInfo.SuppressedRanges), len(tt.wantSuppressedRanges))
+			}
+
+			for i, wantRange := range tt.wantSuppressedRanges {
+				if i >= len(suppressionInfo.SuppressedRanges) {
+					break
+				}
+				gotRange := suppressionInfo.SuppressedRanges[i]
+				if gotRange.StartLine != wantRange.StartLine || gotRange.EndLine != wantRange.EndLine {
+					t.Errorf("SuppressedRange[%d] = {%d, %d}, want {%d, %d}",
+						i, gotRange.StartLine, gotRange.EndLine, wantRange.StartLine, wantRange.EndLine)
+				}
+			}
+
+			if len(*doc.Diagnostics) != tt.wantDiagnosticsCount {
+				t.Errorf("Diagnostics count = %v, want %v", len(*doc.Diagnostics), tt.wantDiagnosticsCount)
+			}
+		})
+	}
+}
+
+func TestIsDiagnosticSuppressed(t *testing.T) {
+	tests := []struct {
+		name            string
+		suppressionInfo *SuppressionInfo
+		diagnostic      protocol.Diagnostic
+		want            bool
+	}{
+		{
+			name:            "Nil suppression info",
+			suppressionInfo: nil,
+			diagnostic: protocol.Diagnostic{
+				Range: protocol.Range{
+					Start: protocol.Position{Line: 5, Character: 0},
+					End:   protocol.Position{Line: 5, Character: 10},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "File-wide suppression",
+			suppressionInfo: &SuppressionInfo{
+				FileWideSuppression: true,
+				SuppressedLines:     map[uint32]bool{},
+				SuppressedRanges:    []SuppressionRange{},
+			},
+			diagnostic: protocol.Diagnostic{
+				Range: protocol.Range{
+					Start: protocol.Position{Line: 5, Character: 0},
+					End:   protocol.Position{Line: 5, Character: 10},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "Line suppressed",
+			suppressionInfo: &SuppressionInfo{
+				FileWideSuppression: false,
+				SuppressedLines:     map[uint32]bool{5: true},
+				SuppressedRanges:    []SuppressionRange{},
+			},
+			diagnostic: protocol.Diagnostic{
+				Range: protocol.Range{
+					Start: protocol.Position{Line: 5, Character: 0},
+					End:   protocol.Position{Line: 5, Character: 10},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "Line not suppressed",
+			suppressionInfo: &SuppressionInfo{
+				FileWideSuppression: false,
+				SuppressedLines:     map[uint32]bool{3: true},
+				SuppressedRanges:    []SuppressionRange{},
+			},
+			diagnostic: protocol.Diagnostic{
+				Range: protocol.Range{
+					Start: protocol.Position{Line: 5, Character: 0},
+					End:   protocol.Position{Line: 5, Character: 10},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "Range suppression - diagnostic at start",
+			suppressionInfo: &SuppressionInfo{
+				FileWideSuppression: false,
+				SuppressedLines:     map[uint32]bool{},
+				SuppressedRanges: []SuppressionRange{
+					{StartLine: 5, EndLine: 10},
+				},
+			},
+			diagnostic: protocol.Diagnostic{
+				Range: protocol.Range{
+					Start: protocol.Position{Line: 5, Character: 0},
+					End:   protocol.Position{Line: 5, Character: 10},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "Range suppression - diagnostic in middle",
+			suppressionInfo: &SuppressionInfo{
+				FileWideSuppression: false,
+				SuppressedLines:     map[uint32]bool{},
+				SuppressedRanges: []SuppressionRange{
+					{StartLine: 5, EndLine: 10},
+				},
+			},
+			diagnostic: protocol.Diagnostic{
+				Range: protocol.Range{
+					Start: protocol.Position{Line: 7, Character: 0},
+					End:   protocol.Position{Line: 7, Character: 10},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "Range suppression - diagnostic at end",
+			suppressionInfo: &SuppressionInfo{
+				FileWideSuppression: false,
+				SuppressedLines:     map[uint32]bool{},
+				SuppressedRanges: []SuppressionRange{
+					{StartLine: 5, EndLine: 10},
+				},
+			},
+			diagnostic: protocol.Diagnostic{
+				Range: protocol.Range{
+					Start: protocol.Position{Line: 10, Character: 0},
+					End:   protocol.Position{Line: 10, Character: 10},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "Range suppression - diagnostic before range",
+			suppressionInfo: &SuppressionInfo{
+				FileWideSuppression: false,
+				SuppressedLines:     map[uint32]bool{},
+				SuppressedRanges: []SuppressionRange{
+					{StartLine: 5, EndLine: 10},
+				},
+			},
+			diagnostic: protocol.Diagnostic{
+				Range: protocol.Range{
+					Start: protocol.Position{Line: 3, Character: 0},
+					End:   protocol.Position{Line: 3, Character: 10},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "Range suppression - diagnostic after range",
+			suppressionInfo: &SuppressionInfo{
+				FileWideSuppression: false,
+				SuppressedLines:     map[uint32]bool{},
+				SuppressedRanges: []SuppressionRange{
+					{StartLine: 5, EndLine: 10},
+				},
+			},
+			diagnostic: protocol.Diagnostic{
+				Range: protocol.Range{
+					Start: protocol.Position{Line: 12, Character: 0},
+					End:   protocol.Position{Line: 12, Character: 10},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "Multi-line diagnostic suppressed by next-line",
+			suppressionInfo: &SuppressionInfo{
+				FileWideSuppression: false,
+				SuppressedLines:     map[uint32]bool{5: true},
+				SuppressedRanges:    []SuppressionRange{},
+			},
+			diagnostic: protocol.Diagnostic{
+				Range: protocol.Range{
+					Start: protocol.Position{Line: 5, Character: 0},
+					End:   protocol.Position{Line: 8, Character: 10},
+				},
+			},
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isDiagnosticSuppressed(tt.suppressionInfo, tt.diagnostic)
+			if got != tt.want {
+				t.Errorf("isDiagnosticSuppressed() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDiagnosticOverlapsRange(t *testing.T) {
+	tests := []struct {
+		name       string
+		r          SuppressionRange
+		diagnostic protocol.Diagnostic
+		want       bool
+	}{
+		{
+			name: "Diagnostic at start of range",
+			r:    SuppressionRange{StartLine: 5, EndLine: 10},
+			diagnostic: protocol.Diagnostic{
+				Range: protocol.Range{
+					Start: protocol.Position{Line: 5, Character: 0},
+					End:   protocol.Position{Line: 5, Character: 10},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "Diagnostic at end of range",
+			r:    SuppressionRange{StartLine: 5, EndLine: 10},
+			diagnostic: protocol.Diagnostic{
+				Range: protocol.Range{
+					Start: protocol.Position{Line: 10, Character: 0},
+					End:   protocol.Position{Line: 10, Character: 10},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "Diagnostic in middle of range",
+			r:    SuppressionRange{StartLine: 5, EndLine: 10},
+			diagnostic: protocol.Diagnostic{
+				Range: protocol.Range{
+					Start: protocol.Position{Line: 7, Character: 0},
+					End:   protocol.Position{Line: 7, Character: 10},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "Diagnostic before range",
+			r:    SuppressionRange{StartLine: 5, EndLine: 10},
+			diagnostic: protocol.Diagnostic{
+				Range: protocol.Range{
+					Start: protocol.Position{Line: 3, Character: 0},
+					End:   protocol.Position{Line: 3, Character: 10},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "Diagnostic after range",
+			r:    SuppressionRange{StartLine: 5, EndLine: 10},
+			diagnostic: protocol.Diagnostic{
+				Range: protocol.Range{
+					Start: protocol.Position{Line: 12, Character: 0},
+					End:   protocol.Position{Line: 12, Character: 10},
+				},
+			},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := diagnosticOverlapsRange(tt.r, tt.diagnostic)
+			if got != tt.want {
+				t.Errorf("diagnosticOverlapsRange() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFilterSuppressedDiagnostics(t *testing.T) {
+	tests := []struct {
+		name            string
+		diagnostics     []protocol.Diagnostic
+		suppressionInfo *SuppressionInfo
+		wantCount       int
+	}{
+		{
+			name: "Filter out file-wide suppressed diagnostics",
+			diagnostics: []protocol.Diagnostic{
+				{Range: protocol.Range{Start: protocol.Position{Line: 1}}},
+				{Range: protocol.Range{Start: protocol.Position{Line: 2}}},
+				{Range: protocol.Range{Start: protocol.Position{Line: 3}}},
+			},
+			suppressionInfo: &SuppressionInfo{
+				FileWideSuppression: true,
+				SuppressedLines:     map[uint32]bool{},
+				SuppressedRanges:    []SuppressionRange{},
+			},
+			wantCount: 0,
+		},
+		{
+			name: "Filter out line-specific suppressions",
+			diagnostics: []protocol.Diagnostic{
+				{Range: protocol.Range{Start: protocol.Position{Line: 1}}},
+				{Range: protocol.Range{Start: protocol.Position{Line: 2}}},
+				{Range: protocol.Range{Start: protocol.Position{Line: 3}}},
+			},
+			suppressionInfo: &SuppressionInfo{
+				FileWideSuppression: false,
+				SuppressedLines:     map[uint32]bool{1: true, 3: true},
+				SuppressedRanges:    []SuppressionRange{},
+			},
+			wantCount: 1,
+		},
+		{
+			name: "Filter out range suppressions",
+			diagnostics: []protocol.Diagnostic{
+				{Range: protocol.Range{Start: protocol.Position{Line: 1}}},
+				{Range: protocol.Range{Start: protocol.Position{Line: 5}}},
+				{Range: protocol.Range{Start: protocol.Position{Line: 7}}},
+				{Range: protocol.Range{Start: protocol.Position{Line: 15}}},
+			},
+			suppressionInfo: &SuppressionInfo{
+				FileWideSuppression: false,
+				SuppressedLines:     map[uint32]bool{},
+				SuppressedRanges: []SuppressionRange{
+					{StartLine: 5, EndLine: 10},
+				},
+			},
+			wantCount: 2,
+		},
+		{
+			name: "No suppressions",
+			diagnostics: []protocol.Diagnostic{
+				{Range: protocol.Range{Start: protocol.Position{Line: 1}}},
+				{Range: protocol.Range{Start: protocol.Position{Line: 2}}},
+				{Range: protocol.Range{Start: protocol.Position{Line: 3}}},
+			},
+			suppressionInfo: &SuppressionInfo{
+				FileWideSuppression: false,
+				SuppressedLines:     map[uint32]bool{},
+				SuppressedRanges:    []SuppressionRange{},
+			},
+			wantCount: 3,
+		},
+		{
+			name: "Mixed suppressions",
+			diagnostics: []protocol.Diagnostic{
+				{Range: protocol.Range{Start: protocol.Position{Line: 1}}},
+				{Range: protocol.Range{Start: protocol.Position{Line: 3}}},
+				{Range: protocol.Range{Start: protocol.Position{Line: 5}}},
+				{Range: protocol.Range{Start: protocol.Position{Line: 7}}},
+				{Range: protocol.Range{Start: protocol.Position{Line: 15}}},
+			},
+			suppressionInfo: &SuppressionInfo{
+				FileWideSuppression: false,
+				SuppressedLines:     map[uint32]bool{3: true},
+				SuppressedRanges: []SuppressionRange{
+					{StartLine: 5, EndLine: 10},
+				},
+			},
+			wantCount: 2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := FilterSuppressedDiagnostics(tt.diagnostics, tt.suppressionInfo)
+			if len(got) != tt.wantCount {
+				t.Errorf("FilterSuppressedDiagnostics() returned %v diagnostics, want %v", len(got), tt.wantCount)
+			}
+		})
+	}
+}

--- a/pkg/parser/yamlparser.go
+++ b/pkg/parser/yamlparser.go
@@ -43,6 +43,8 @@ func (doc *YamlDocument) ParseYAML(context *utils.LsContext, offset protocol.Pos
 	blockMappingNode := GetBlockMappingNode(doc.RootNode)
 	doc.YamlAnchors = ParseYamlAnchors(doc)
 
+	doc.SuppressionInfo = ParseSuppressionComments(doc)
+
 	doc.iterateOnBlockMapping(blockMappingNode, func(child *sitter.Node) {
 		keyNode, valueNode := doc.GetKeyValueNodes(child)
 		keyName := doc.GetNodeText(keyNode)
@@ -215,6 +217,8 @@ type YamlDocument struct {
 
 	LocalOrbName string
 	Offset       protocol.Position
+
+	SuppressionInfo *SuppressionInfo
 }
 
 func (doc *YamlDocument) IsBuiltIn(commandName string) bool {

--- a/pkg/services/diagnostics.go
+++ b/pkg/services/diagnostics.go
@@ -86,6 +86,15 @@ func DiagnosticYAML(yamlDocument yamlparser.YamlDocument, cache *utils.Cache, co
 	validateStruct.Validate()
 	diag.addDiagnostics(*validateStruct.Diagnostics)
 
+	// after ALL diagnostics are added, filter out the ones that the user wishes to suppress via cci-ignore comments
+	*diag.diagnostics = yamlparser.FilterSuppressedDiagnostics(*diag.diagnostics, diag.yamlDocument.SuppressionInfo)
+
+	// append some extra add code actions to every diagnostic to suppress said diagnostic
+	*diag.diagnostics, err = utils.AppendSuppressionCodeActions(yamlDocument.URI, *diag.diagnostics, yamlDocument.Content)
+	if err != nil {
+		return []protocol.Diagnostic{}, err
+	}
+
 	return *diag.diagnostics, nil
 }
 

--- a/pkg/utils/codeActions.go
+++ b/pkg/utils/codeActions.go
@@ -1,8 +1,10 @@
 package utils
 
 import (
+	"github.com/segmentio/encoding/json"
 	"go.lsp.dev/protocol"
 	"go.lsp.dev/uri"
+	"strings"
 )
 
 func CreateCodeActionTextEdit(title string, textDocumentUri uri.URI, textEdits []protocol.TextEdit, isPreferred bool) protocol.CodeAction {
@@ -16,4 +18,153 @@ func CreateCodeActionTextEdit(title string, textDocumentUri uri.URI, textEdits [
 		},
 		IsPreferred: isPreferred,
 	}
+}
+
+func AppendSuppressionCodeActions(docURI protocol.URI, diagnostics []protocol.Diagnostic, docContent []byte) ([]protocol.Diagnostic, error) {
+	newDiagnostics := []protocol.Diagnostic{}
+
+	docLines := strings.Split(string(docContent), "\n")
+
+	for _, diagnostic := range diagnostics {
+		// Extract indentation from the line where diagnostic occurs
+		indent := ""
+		if int(diagnostic.Range.Start.Line) < len(docLines) {
+			lineText := docLines[diagnostic.Range.Start.Line]
+			for _, ch := range lineText {
+				if ch == ' ' || ch == '\t' {
+					indent += string(ch)
+				} else {
+					break
+				}
+			}
+		}
+
+		// Suggest to ignore next line first as it applies to both single and multi-line diagnostics.
+		ignoreActions := []protocol.CodeAction{
+			CreateCodeActionTextEdit(
+				"Ignore this line",
+				docURI,
+				[]protocol.TextEdit{
+					{
+						NewText: indent + "# cci-ignore-next-line\n",
+						Range: protocol.Range{
+							Start: protocol.Position{
+								Character: 0,
+								Line:      diagnostic.Range.Start.Line,
+							},
+							End: protocol.Position{
+								Character: 0,
+								Line:      diagnostic.Range.Start.Line,
+							},
+						},
+					},
+				},
+				false, // not preferred
+			),
+		}
+
+		if diagnostic.Range.Start.Line == diagnostic.Range.End.Line {
+			// Single-line diagnostic, offer to put an inline comment
+			ignoreActions = append(ignoreActions, CreateCodeActionTextEdit(
+				"Ignore this line (inline)",
+				docURI,
+				[]protocol.TextEdit{
+					{
+						NewText: " # cci-ignore",
+						Range: protocol.Range{
+							Start: protocol.Position{
+								Character: diagnostic.Range.End.Character + 1,
+								Line:      diagnostic.Range.Start.Line,
+							},
+							End: protocol.Position{
+								Character: diagnostic.Range.End.Character + 14,
+								Line:      diagnostic.Range.Start.Line,
+							},
+						},
+					},
+				},
+				false, // not preferred
+			))
+		} else {
+			// Otherwise it's a multi-line diagnostic. Offer to ignore a range.
+			// NOTE: This doesn't handle if there are separate diagnostics on multiple lines in a row.
+			ignoreActions = append(ignoreActions, CreateCodeActionTextEdit(
+				"Ignore this range",
+				docURI,
+				[]protocol.TextEdit{
+					{
+						NewText: indent + "# cci-ignore-start\n",
+						Range: protocol.Range{
+							Start: protocol.Position{
+								Character: 0,
+								Line:      diagnostic.Range.Start.Line,
+							},
+							End: protocol.Position{
+								Character: 0,
+								Line:      diagnostic.Range.Start.Line,
+							},
+						},
+					},
+					{
+						NewText: indent + "# cci-ignore-end\n",
+						Range: protocol.Range{
+							Start: protocol.Position{
+								Character: 0,
+								Line:      diagnostic.Range.End.Line + 1,
+							},
+							End: protocol.Position{
+								Character: 0,
+								Line:      diagnostic.Range.End.Line + 1,
+							},
+						},
+					},
+				},
+				false, // not preferred
+			))
+		}
+
+		// Suggest to ignore the entire file last as we don't want to encourage this.
+		ignoreActions = append(ignoreActions,
+			CreateCodeActionTextEdit(
+				"Ignore all errors in this file",
+				docURI,
+				[]protocol.TextEdit{
+					{
+						NewText: "# cci-ignore-file\n",
+						Range: protocol.Range{
+							Start: protocol.Position{
+								Character: 0,
+								Line:      0,
+							},
+							End: protocol.Position{
+								Character: 0,
+								Line:      0,
+							},
+						},
+					},
+				},
+				false, // not preferred
+			),
+		)
+
+		// Append to existing code actions if there are any.
+		existingActions := []protocol.CodeAction{}
+		if diagnostic.Data != nil {
+			// Unmarshal existing code actions
+			str, err := json.Marshal(diagnostic.Data)
+			if err != nil {
+				return nil, err
+			}
+
+			err = json.Unmarshal(str, &existingActions)
+			if err != nil {
+				return nil, err
+			}
+		}
+
+		diagnostic.Data = append(existingActions, ignoreActions...)
+		newDiagnostics = append(newDiagnostics, diagnostic)
+	}
+
+	return newDiagnostics, nil
 }

--- a/pkg/utils/codeActions_test.go
+++ b/pkg/utils/codeActions_test.go
@@ -1,0 +1,188 @@
+package utils
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.lsp.dev/protocol"
+)
+
+func TestAppendSuppressionCodeActions(t *testing.T) {
+	docURI := protocol.URI("file:///test.yml")
+
+	tests := []struct {
+		name                 string
+		diagnostics          []protocol.Diagnostic
+		docContent           []byte
+		wantCodeActionTitles []string
+		validateEdit         func(t *testing.T, actions []protocol.CodeAction)
+	}{
+		{
+			name: "Indentation preservation",
+			diagnostics: []protocol.Diagnostic{
+				{
+					Range: protocol.Range{
+						Start: protocol.Position{Line: 1, Character: 4},
+						End:   protocol.Position{Line: 1, Character: 10},
+					},
+					Message: "Test error",
+				},
+			},
+			docContent: []byte("version: 2.1\n    indented: line\n"),
+			validateEdit: func(t *testing.T, actions []protocol.CodeAction) {
+				// Find "Ignore this line" action
+				for _, action := range actions {
+					if action.Title == "Ignore this line" {
+						edits := action.Edit.Changes[docURI]
+						assert.Equal(t, "    # cci-ignore-next-line\n", edits[0].NewText)
+						return
+					}
+				}
+				t.Error("'Ignore this line' action not found")
+			},
+		},
+		{
+			name: "Inline suppression",
+			diagnostics: []protocol.Diagnostic{
+				{
+					Range: protocol.Range{
+						Start: protocol.Position{Line: 0, Character: 0},
+						End:   protocol.Position{Line: 0, Character: 7},
+					},
+					Message: "Single line error",
+				},
+			},
+			docContent: []byte("version: 2.1"),
+			wantCodeActionTitles: []string{
+				"Ignore this line",
+				"Ignore this line (inline)",
+				"Ignore all errors in this file",
+			},
+			validateEdit: func(t *testing.T, actions []protocol.CodeAction) {
+				// Find inline action
+				for _, action := range actions {
+					if action.Title == "Ignore this line (inline)" {
+						edits := action.Edit.Changes[docURI]
+						assert.Equal(t, " # cci-ignore", edits[0].NewText)
+						return
+					}
+				}
+				t.Error("'Ignore this line (inline)' action not found")
+			},
+		},
+		{
+			name: "Next line suppression",
+			diagnostics: []protocol.Diagnostic{
+				{
+					Range: protocol.Range{
+						Start: protocol.Position{Line: 1, Character: 0},
+						End:   protocol.Position{Line: 1, Character: 4},
+					},
+					Message: "Test error",
+				},
+			},
+			docContent: []byte("version: 2.1\njobs:\n  test: value"),
+			validateEdit: func(t *testing.T, actions []protocol.CodeAction) {
+				// Find next line action
+				for _, action := range actions {
+					if action.Title == "Ignore this line" {
+						edits := action.Edit.Changes[docURI]
+						assert.Equal(t, "# cci-ignore-next-line\n", edits[0].NewText)
+						assert.Equal(t, uint32(1), edits[0].Range.Start.Line)
+						return
+					}
+				}
+				t.Error("'Ignore this line' action not found")
+			},
+		},
+		{
+			name: "Range suppression",
+			diagnostics: []protocol.Diagnostic{
+				{
+					Range: protocol.Range{
+						Start: protocol.Position{Line: 1, Character: 0},
+						End:   protocol.Position{Line: 3, Character: 5},
+					},
+					Message: "Multi-line error",
+				},
+			},
+			docContent: []byte("version: 2.1\njobs:\n  test:\n    docker:\n"),
+			wantCodeActionTitles: []string{
+				"Ignore this line",
+				"Ignore this range",
+				"Ignore all errors in this file",
+			},
+			validateEdit: func(t *testing.T, actions []protocol.CodeAction) {
+				// Find range action
+				for _, action := range actions {
+					if action.Title == "Ignore this range" {
+						edits := action.Edit.Changes[docURI]
+						assert.Len(t, edits, 2)
+						assert.Equal(t, "# cci-ignore-start\n", edits[0].NewText)
+						assert.Equal(t, uint32(1), edits[0].Range.Start.Line)
+						assert.Equal(t, "# cci-ignore-end\n", edits[1].NewText)
+						assert.Equal(t, uint32(4), edits[1].Range.Start.Line)
+						return
+					}
+				}
+				t.Error("'Ignore this range' action not found")
+			},
+		},
+		{
+			name: "Preserve existing code actions",
+			diagnostics: []protocol.Diagnostic{
+				{
+					Range: protocol.Range{
+						Start: protocol.Position{Line: 0, Character: 0},
+						End:   protocol.Position{Line: 0, Character: 7},
+					},
+					Message: "Test error",
+					Data: []protocol.CodeAction{
+						{
+							Title: "Existing action",
+							Kind:  "quickfix",
+						},
+					},
+				},
+			},
+			docContent: []byte("version: 2.1"),
+			validateEdit: func(t *testing.T, actions []protocol.CodeAction) {
+				// Check that existing action is preserved
+				found := false
+				for _, action := range actions {
+					if action.Title == "Existing action" {
+						found = true
+						break
+					}
+				}
+				assert.True(t, found, "Existing code action should be preserved")
+				assert.GreaterOrEqual(t, len(actions), 4, "Should have existing + suppression actions")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := AppendSuppressionCodeActions(docURI, tt.diagnostics, tt.docContent)
+			assert.NoError(t, err)
+			assert.Len(t, result, len(tt.diagnostics))
+
+			actions, ok := result[0].Data.([]protocol.CodeAction)
+			assert.True(t, ok)
+
+			if len(tt.wantCodeActionTitles) > 0 {
+				titles := make([]string, len(actions))
+				for j, action := range actions {
+					titles[j] = action.Title
+				}
+				for _, expectedTitle := range tt.wantCodeActionTitles {
+					assert.Contains(t, titles, expectedTitle)
+				}
+			}
+
+			if tt.validateEdit != nil {
+				tt.validateEdit(t, actions)
+			}
+		})
+	}
+}


### PR DESCRIPTION
# Description

Adds some special comment syntax that will ignore diagnostics + some code actions that will suggest to do so for each diagnostic.


https://github.com/user-attachments/assets/d5c40380-1c19-4eb5-8d9f-0612438c90a3



## Issues addressed

### Github

- Addresses #305. 
- Offers a comment-based solution for #308, rather than an actual feature of the VSCode extension to disable the language server
- Semi-addresses the issue #310.


### Canny

- Semi-addresses [this post](https://circleci.canny.io/cloud-feature-requests/p/option-to-disable-config-file-validation) with a comment-based solution
- Addresses [this post](https://circleci.canny.io/cloud-feature-requests/p/add-support-for-suppressing-warnings-errors-per-line-in-config-validation) directly 

# Implementation details

- `cci-ignore` (inline)
- `cci-ignore-file`
- `cci-ignore-next-line`
- `cci-ignore-start` + `cci-ignore-end` (range)

# How to validate

Follow the steps in `HACKING.md` and try it out for yourself!

