### PR TITLE
feat: Extend the `requires` schema of a workflow job

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -2115,7 +2115,8 @@
                                                                             "enum": [
                                                                                 "success",
                                                                                 "failed",
-                                                                                "canceled"
+                                                                                "canceled",
+                                                                                "not_run"
                                                                             ]
                                                                         },
                                                                         {
@@ -2126,7 +2127,8 @@
                                                                                 "enum": [
                                                                                     "success",
                                                                                     "failed",
-                                                                                    "canceled"
+                                                                                    "canceled",
+                                                                                    "not_run"
                                                                                 ]
                                                                             }
                                                                         }


### PR DESCRIPTION


[Jira](https://circleci.atlassian.net/browse/PIPE-5119)

# Description

We updated our config schema to allow configuring a  job to run when an upstream dependency is not run. `not_run` is now available as a state to use in the requires stanza, for example:

```
workflows:
  a:
    jobs:
      - deploy
      - release:
          requires:
            - deploy
      - notify:
          requires:
            - release: [success, failed, canceled, not_run]
```

# Implementation details

- Update the schema to include the new `not_run` requires state

