### PR TITLE
feat: [PIPE-5387] add "terminal" shorthand for upstream job requires array

### DIFF
--- a/pkg/ast/workflow.go
+++ b/pkg/ast/workflow.go
@@ -52,9 +52,10 @@ type JobRef struct {
 }
 
 type Require struct {
-	Name   string
-	Status []string
-	Range  protocol.Range
+	Name        string
+	Status      []string
+	Range       protocol.Range
+	StatusRange protocol.Range
 }
 
 type WorkflowTrigger struct {

--- a/pkg/parser/workflows_test.go
+++ b/pkg/parser/workflows_test.go
@@ -150,6 +150,10 @@ func TestYamlDocument_parseSingleJobReference(t *testing.T) {
 							Start: protocol.Position{Line: 3, Character: 10},
 							End:   protocol.Position{Line: 3, Character: 15},
 						},
+						StatusRange: protocol.Range{
+							Start: protocol.Position{Line: 3, Character: 10},
+							End:   protocol.Position{Line: 3, Character: 15},
+						},
 					},
 				},
 				MatrixParams: make(map[string][]ast.ParameterValue),
@@ -364,6 +368,10 @@ func TestYamlDocument_parseSingleJobReference(t *testing.T) {
 							Start: protocol.Position{Line: 3, Character: 10},
 							End:   protocol.Position{Line: 3, Character: 15},
 						},
+						StatusRange: protocol.Range{
+							Start: protocol.Position{Line: 3, Character: 17},
+							End:   protocol.Position{Line: 3, Character: 23},
+						},
 					},
 				},
 				MatrixParams: make(map[string][]ast.ParameterValue),
@@ -414,6 +422,10 @@ func TestYamlDocument_parseSingleJobReference(t *testing.T) {
 						Range: protocol.Range{
 							Start: protocol.Position{Line: 3, Character: 10},
 							End:   protocol.Position{Line: 3, Character: 15},
+						},
+						StatusRange: protocol.Range{
+							Start: protocol.Position{Line: 3, Character: 17},
+							End:   protocol.Position{Line: 3, Character: 36},
 						},
 					},
 				},

--- a/pkg/services/diagnostics_test.go
+++ b/pkg/services/diagnostics_test.go
@@ -69,3 +69,213 @@ func TestFindErrors(t *testing.T) {
 		})
 	}
 }
+
+func TestDeduplicateDiagnosticsByRange(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    []protocol.Diagnostic
+		expected []protocol.Diagnostic
+	}{
+		{
+			name: "Remove exact duplicates",
+			input: []protocol.Diagnostic{
+				{
+					Range: protocol.Range{
+						Start: protocol.Position{Line: 1, Character: 0},
+						End:   protocol.Position{Line: 1, Character: 10},
+					},
+					Message:  "Test error",
+					Severity: protocol.DiagnosticSeverityError,
+				},
+				{
+					Range: protocol.Range{
+						Start: protocol.Position{Line: 1, Character: 0},
+						End:   protocol.Position{Line: 1, Character: 10},
+					},
+					Message:  "Test error",
+					Severity: protocol.DiagnosticSeverityError,
+				},
+			},
+			expected: []protocol.Diagnostic{
+				{
+					Range: protocol.Range{
+						Start: protocol.Position{Line: 1, Character: 0},
+						End:   protocol.Position{Line: 1, Character: 10},
+					},
+					Message:  "Test error",
+					Severity: protocol.DiagnosticSeverityError,
+				},
+			},
+		},
+		{
+			name: "Keep different ranges",
+			input: []protocol.Diagnostic{
+				{
+					Range: protocol.Range{
+						Start: protocol.Position{Line: 1, Character: 0},
+						End:   protocol.Position{Line: 1, Character: 10},
+					},
+					Message:  "Test error",
+					Severity: protocol.DiagnosticSeverityError,
+				},
+				{
+					Range: protocol.Range{
+						Start: protocol.Position{Line: 2, Character: 0},
+						End:   protocol.Position{Line: 2, Character: 10},
+					},
+					Message:  "Test error",
+					Severity: protocol.DiagnosticSeverityError,
+				},
+			},
+			expected: []protocol.Diagnostic{
+				{
+					Range: protocol.Range{
+						Start: protocol.Position{Line: 1, Character: 0},
+						End:   protocol.Position{Line: 1, Character: 10},
+					},
+					Message:  "Test error",
+					Severity: protocol.DiagnosticSeverityError,
+				},
+				{
+					Range: protocol.Range{
+						Start: protocol.Position{Line: 2, Character: 0},
+						End:   protocol.Position{Line: 2, Character: 10},
+					},
+					Message:  "Test error",
+					Severity: protocol.DiagnosticSeverityError,
+				},
+			},
+		},
+		{
+			name: "Keep same range different messages",
+			input: []protocol.Diagnostic{
+				{
+					Range: protocol.Range{
+						Start: protocol.Position{Line: 1, Character: 0},
+						End:   protocol.Position{Line: 1, Character: 10},
+					},
+					Message:  "Error 1",
+					Severity: protocol.DiagnosticSeverityError,
+				},
+				{
+					Range: protocol.Range{
+						Start: protocol.Position{Line: 1, Character: 0},
+						End:   protocol.Position{Line: 1, Character: 10},
+					},
+					Message:  "Error 2",
+					Severity: protocol.DiagnosticSeverityError,
+				},
+			},
+			expected: []protocol.Diagnostic{
+				{
+					Range: protocol.Range{
+						Start: protocol.Position{Line: 1, Character: 0},
+						End:   protocol.Position{Line: 1, Character: 10},
+					},
+					Message:  "Error 1",
+					Severity: protocol.DiagnosticSeverityError,
+				},
+				{
+					Range: protocol.Range{
+						Start: protocol.Position{Line: 1, Character: 0},
+						End:   protocol.Position{Line: 1, Character: 10},
+					},
+					Message:  "Error 2",
+					Severity: protocol.DiagnosticSeverityError,
+				},
+			},
+		},
+		{
+			name: "Keep same range different severities",
+			input: []protocol.Diagnostic{
+				{
+					Range: protocol.Range{
+						Start: protocol.Position{Line: 1, Character: 0},
+						End:   protocol.Position{Line: 1, Character: 10},
+					},
+					Message:  "Test error",
+					Severity: protocol.DiagnosticSeverityError,
+				},
+				{
+					Range: protocol.Range{
+						Start: protocol.Position{Line: 1, Character: 0},
+						End:   protocol.Position{Line: 1, Character: 10},
+					},
+					Message:  "Test error",
+					Severity: protocol.DiagnosticSeverityWarning,
+				},
+			},
+			expected: []protocol.Diagnostic{
+				{
+					Range: protocol.Range{
+						Start: protocol.Position{Line: 1, Character: 0},
+						End:   protocol.Position{Line: 1, Character: 10},
+					},
+					Message:  "Test error",
+					Severity: protocol.DiagnosticSeverityError,
+				},
+				{
+					Range: protocol.Range{
+						Start: protocol.Position{Line: 1, Character: 0},
+						End:   protocol.Position{Line: 1, Character: 10},
+					},
+					Message:  "Test error",
+					Severity: protocol.DiagnosticSeverityWarning,
+				},
+			},
+		},
+		{
+			name: "Remove multiple duplicates",
+			input: []protocol.Diagnostic{
+				{
+					Range: protocol.Range{
+						Start: protocol.Position{Line: 1, Character: 0},
+						End:   protocol.Position{Line: 1, Character: 10},
+					},
+					Message:  "Test error",
+					Severity: protocol.DiagnosticSeverityError,
+				},
+				{
+					Range: protocol.Range{
+						Start: protocol.Position{Line: 1, Character: 0},
+						End:   protocol.Position{Line: 1, Character: 10},
+					},
+					Message:  "Test error",
+					Severity: protocol.DiagnosticSeverityError,
+				},
+				{
+					Range: protocol.Range{
+						Start: protocol.Position{Line: 1, Character: 0},
+						End:   protocol.Position{Line: 1, Character: 10},
+					},
+					Message:  "Test error",
+					Severity: protocol.DiagnosticSeverityError,
+				},
+			},
+			expected: []protocol.Diagnostic{
+				{
+					Range: protocol.Range{
+						Start: protocol.Position{Line: 1, Character: 0},
+						End:   protocol.Position{Line: 1, Character: 10},
+					},
+					Message:  "Test error",
+					Severity: protocol.DiagnosticSeverityError,
+				},
+			},
+		},
+		{
+			name:     "Empty input",
+			input:    []protocol.Diagnostic{},
+			expected: []protocol.Diagnostic{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := deduplicateDiagnosticsByRange(tt.input)
+			if !reflect.DeepEqual(result, tt.expected) {
+				t.Errorf("deduplicateDiagnosticsByRange() = %v, want %v", result, tt.expected)
+			}
+		})
+	}
+}

--- a/schema.json
+++ b/schema.json
@@ -2151,12 +2151,23 @@
                                                                 "^[A-Za-z][A-Za-z\\s\\d_-]*$": {
                                                                     "oneOf": [
                                                                         {
-                                                                            "type": "string",
-                                                                            "enum": [
-                                                                                "success",
-                                                                                "failed",
-                                                                                "canceled",
-                                                                                "not_run"
+                                                                            "oneOf": [
+                                                                                {
+                                                                                    "const": "success"
+                                                                                },
+                                                                                {
+                                                                                    "const": "failed"
+                                                                                },
+                                                                                {
+                                                                                    "const": "canceled"
+                                                                                },
+                                                                                {
+                                                                                    "const": "not_run"
+                                                                                },
+                                                                                {
+                                                                                    "const": "terminal",
+                                                                                    "markdownDescription": "Shorthand for `[success, failed, canceled, not_run]` - matches when the upstream job has reached any terminal state."
+                                                                                }
                                                                             ]
                                                                         },
                                                                         {


### PR DESCRIPTION


Jira: https://circleci.atlassian.net/browse/PIPE-5387

**Important note** : Release-please will only create a release PR for releases with a `feat` or `fix` commit message. If your PR starts with `chore` , your changes will NOT be released.

# Description

Adds the ability to use "terminal" in place of [success, failure, canceled, not_run] when specifying the upstream job requirements.

Also adds a small hint to users that they can do this, with a code action to do it for them.


https://github.com/user-attachments/assets/8c976618-9457-4660-b727-df7836ffe2a6


https://github.com/user-attachments/assets/09e6da7d-26d5-44e0-a991-198eb9392fae


Plus a description hover hint if using terminal.
<img width="942" height="230" alt="image" src="https://github.com/user-attachments/assets/78eaad45-f0f8-483b-9859-96cfb5afd9cd" />


# Implementation details

- adds "terminal" as a valid enum for upstream job requires  in `schema.json`
- adds a hint diagnostic if the user has an array with all the valid terminal job statuses to just replace it with "terminal"
- adds a code action to the diagnostic to do the work for them
- adds tests for these scenarios


Other fixes:
- Adds a diagnostic de-duplication pass at the end to remove diagnostics that are repeated due to anchor usage. This was an existing issue that I found while working on this change. 

# How to validate

Follow the steps in CONTRIBUTING.md to run the extension locally and try it out yourself. 

