### PR TITLE
feat: Add gen2 linux resource classes and images

### DIFF
--- a/pkg/utils/executors.go
+++ b/pkg/utils/executors.go
@@ -94,6 +94,16 @@ var ValidLinuxImages = []string{
 	"android:202102-01",
 }
 
+var ValidLinuxGen2Images = []string{
+	// Ubuntu 22.04
+	"ubuntu-2204:current",
+	"ubuntu-2204:edge",
+
+	// Ubuntu 24.04
+	"ubuntu-2404:current",
+	"ubuntu-2404:edge",
+}
+
 var ValidLinuxResourceClasses = []string{
 	"small",
 	"medium",
@@ -110,6 +120,14 @@ var ValidLinuxResourceClasses = []string{
 	// Special case: missing resource class or empty string means default linux
 	// resource class
 	"",
+}
+
+var ValidLinuxGen2ResourceClasses = []string{
+	"medium-gen2",
+	"large-gen2",
+	"xlarge-gen2",
+	"2xlarge-gen2",
+	"2xlarge+-gen2",
 }
 
 var ValidWindowsImages = []string{
@@ -198,6 +216,7 @@ var ValidMachineResourceClasses = slices.Concat(
 	ValidWindowsResourceClasses,
 	ValidLinuxGPUResourceClasses,
 	ValidWindowsGPUResourceClasses,
+	ValidLinuxGen2ResourceClasses,
 )
 
 var ValidMachineImages = slices.Concat(
@@ -205,6 +224,7 @@ var ValidMachineImages = slices.Concat(
 	ValidWindowsImages,
 	ValidLinuxGPUImages,
 	ValidWindowsGPUImages,
+	ValidLinuxGen2Images,
 )
 
 var ValidMachinePairs = []struct {
@@ -215,6 +235,7 @@ var ValidMachinePairs = []struct {
 	{Images: ValidWindowsImages, ResourceClasses: ValidWindowsResourceClasses},
 	{Images: ValidLinuxGPUImages, ResourceClasses: ValidLinuxGPUResourceClasses},
 	{Images: ValidWindowsGPUImages, ResourceClasses: ValidWindowsGPUResourceClasses},
+	{Images: ValidLinuxGen2Images, ResourceClasses: ValidLinuxGen2ResourceClasses},
 }
 
 var ValidXcodeVersions = []string{

--- a/schema.json
+++ b/schema.json
@@ -1642,7 +1642,12 @@
                                             "m2pro.medium",
                                             "m2pro.large",
                                             "m4pro.medium",
-                                            "m4pro.large"
+                                            "m4pro.large",
+                                            "medium-gen2",
+                                            "large-gen2",
+                                            "xlarge-gen2",
+                                            "2xlarge-gen2",
+                                            "2xlarge+-gen2"
                                         ]
                                     },
                                     {


### PR DESCRIPTION
**Important note** : Release-please will only create a release PR for releases with a `feat` or `fix` commit message. If your PR starts with `chore` , your changes will NOT be released.

# Description

Adds validation support for gen2 Linux machine images and resource classes in the YAML language server. This enables autocomplete and validation for the new generation 2 Linux resource classes (medium-gen2, large-gen2, xlarge-gen2, 2xlarge-gen2, 2xlarge+-gen2) and their compatible Ubuntu images (ubuntu-2204 and ubuntu-2404).

# Implementation details

  Added `ValidLinuxGen2Images` and `ValidLinuxGen2ResourceClasses` arrays in `pkg/utils/executors.go` and concatenated them into the existing validation lists.
# How to validate

  1. Open a CircleCI config.yml in VS Code with the language server extension installed
  2. Add a machine executor with `image: ubuntu-2204:current` and `resource_class: medium-gen2`
  3. Verify autocomplete suggestions include the gen2 resource classes and Ubuntu 22.04/24.04 images
  4. Confirm no validation errors appear for valid gen2 image/resource class combinations

