### PR TITLE
feat: support parameter interpolation for max_auto_reruns

### DIFF
--- a/pkg/parser/validate/steps.go
+++ b/pkg/parser/validate/steps.go
@@ -68,8 +68,9 @@ func (val Validate) validateRunCommand(step ast.Run, jobOrCommandParameters map[
 		})
 	}
 
-	// Validate that max_auto_reruns is between 1 and 5
-	if step.MaxAutoReruns != "" {
+	// Validate that max_auto_reruns is between 1 and 5;
+	// skip validation when the value is a parameter expression (resolved at compile time)
+	if step.MaxAutoReruns != "" && !utils.CheckIfOnlyParamUsed(step.MaxAutoReruns) {
 		rerunCount, err := strconv.Atoi(step.MaxAutoReruns)
 		if err != nil || rerunCount <= 0 || rerunCount > 5 {
 			val.addDiagnostic(protocol.Diagnostic{

--- a/pkg/parser/validate/steps_test.go
+++ b/pkg/parser/validate/steps_test.go
@@ -80,6 +80,59 @@ workflows:
 			OnlyErrors:  true,
 			Diagnostics: []protocol.Diagnostic{},
 		},
+		{
+			Name: "Valid usage of max_auto_reruns with parameter expression",
+			YamlContent: `version: 2.1
+
+jobs:
+  test-job:
+    docker:
+      - image: cimg/base:stable
+    parameters:
+      retries:
+        type: integer
+        default: 3
+    steps:
+      - run:
+          name: "Task with parameterized reruns"
+          command: "echo test"
+          max_auto_reruns: << parameters.retries >>
+
+workflows:
+  test-workflow:
+    jobs:
+      - test-job
+`,
+			OnlyErrors:  true,
+			Diagnostics: []protocol.Diagnostic{},
+		},
+		{
+			Name: "Valid usage of max_auto_reruns with pipeline parameter expression",
+			YamlContent: `version: 2.1
+
+parameters:
+  retries:
+    type: integer
+    default: 2
+
+jobs:
+  test-job:
+    docker:
+      - image: cimg/base:stable
+    steps:
+      - run:
+          name: "Task with pipeline parameterized reruns"
+          command: "echo test"
+          max_auto_reruns: << pipeline.parameters.retries >>
+
+workflows:
+  test-workflow:
+    jobs:
+      - test-job
+`,
+			OnlyErrors:  true,
+			Diagnostics: []protocol.Diagnostic{},
+		},
 	}
 
 	CheckYamlErrors(t, testCases)

--- a/pkg/parser/validate/steps_test.go
+++ b/pkg/parser/validate/steps_test.go
@@ -133,6 +133,106 @@ workflows:
 			OnlyErrors:  true,
 			Diagnostics: []protocol.Diagnostic{},
 		},
+		{
+			Name: "Invalid usage of max_auto_reruns with out-of-range integer",
+			YamlContent: `version: 2.1
+
+jobs:
+  test-job:
+    docker:
+      - image: cimg/base:stable
+    steps:
+      - run:
+          name: "Task with too many reruns"
+          command: "echo test"
+          max_auto_reruns: 10
+
+workflows:
+  test-workflow:
+    jobs:
+      - test-job
+`,
+			OnlyErrors: true,
+			Diagnostics: []protocol.Diagnostic{
+				{
+					Severity: protocol.DiagnosticSeverityError,
+					Range: protocol.Range{
+						Start: protocol.Position{Line: 7, Character: 8},
+						End:   protocol.Position{Line: 7, Character: 11},
+					},
+					Message: "max_auto_reruns must be between 1 and 5",
+				},
+			},
+		},
+		{
+			Name: "Invalid usage of max_auto_reruns with a non-numeric string",
+			YamlContent: `version: 2.1
+
+jobs:
+  test-job:
+    docker:
+      - image: cimg/base:stable
+    steps:
+      - run:
+          name: "Task with garbage reruns"
+          command: "echo test"
+          max_auto_reruns: "garbage"
+
+workflows:
+  test-workflow:
+    jobs:
+      - test-job
+`,
+			OnlyErrors: true,
+			Diagnostics: []protocol.Diagnostic{
+				{
+					Severity: protocol.DiagnosticSeverityError,
+					Range: protocol.Range{
+						Start: protocol.Position{Line: 7, Character: 8},
+						End:   protocol.Position{Line: 7, Character: 11},
+					},
+					Message: "max_auto_reruns must be between 1 and 5",
+				},
+			},
+		},
+		{
+			// Guards the CheckIfOnlyParamUsed exemption: a parameter expression
+			// embedded in a larger string is not deferred to compile time, so the
+			// range check must still fire.
+			Name: "Invalid usage of max_auto_reruns with a partial parameter expression",
+			YamlContent: `version: 2.1
+
+jobs:
+  test-job:
+    docker:
+      - image: cimg/base:stable
+    parameters:
+      retries:
+        type: integer
+        default: 3
+    steps:
+      - run:
+          name: "Task with a partially interpolated rerun count"
+          command: "echo test"
+          max_auto_reruns: "<< parameters.retries >> 7"
+
+workflows:
+  test-workflow:
+    jobs:
+      - test-job
+`,
+			OnlyErrors: true,
+			Diagnostics: []protocol.Diagnostic{
+				{
+					Severity: protocol.DiagnosticSeverityError,
+					Range: protocol.Range{
+						Start: protocol.Position{Line: 11, Character: 8},
+						End:   protocol.Position{Line: 11, Character: 11},
+					},
+					Message: "max_auto_reruns must be between 1 and 5",
+				},
+			},
+		},
 	}
 
 	CheckYamlErrors(t, testCases)

--- a/pkg/parser/validate/workflow_test.go
+++ b/pkg/parser/validate/workflow_test.go
@@ -155,6 +155,54 @@ workflows:
 				},
 			},
 		},
+		{
+			Name: "Valid max_auto_reruns with pipeline parameter expression",
+			YamlContent: `version: 2.1
+
+parameters:
+  retries:
+    type: integer
+    default: 3
+
+jobs:
+  test-job:
+    docker:
+      - image: cimg/base:stable
+    steps:
+      - run: echo "test"
+
+workflows:
+  test-workflow:
+    max_auto_reruns: << pipeline.parameters.retries >>
+    jobs:
+      - test-job`,
+			OnlyErrors:  true,
+			Diagnostics: []protocol.Diagnostic{},
+		},
+		{
+			Name: "Valid max_auto_reruns with another pipeline parameter expression",
+			YamlContent: `version: 2.1
+
+parameters:
+  max-reruns:
+    type: integer
+    default: 2
+
+jobs:
+  test-job:
+    docker:
+      - image: cimg/base:stable
+    steps:
+      - run: echo "test"
+
+workflows:
+  test-workflow:
+    max_auto_reruns: << pipeline.parameters.max-reruns >>
+    jobs:
+      - test-job`,
+			OnlyErrors:  true,
+			Diagnostics: []protocol.Diagnostic{},
+		},
 	}
 
 	CheckYamlErrors(t, testCases)

--- a/pkg/parser/validate/workflow_test.go
+++ b/pkg/parser/validate/workflow_test.go
@@ -203,6 +203,40 @@ workflows:
 			OnlyErrors:  true,
 			Diagnostics: []protocol.Diagnostic{},
 		},
+		{
+			// Workflows have no job/command parameter scope, so a plain
+			// `<< parameters.x >>` here is exempted from the range check but still
+			// reported by CheckIfParamsExist -- the accurate error, rather than a
+			// misleading "Must be greater than or equal to 1".
+			Name: "max_auto_reruns with a job-scoped parameter expression reports the undefined parameter",
+			YamlContent: `version: 2.1
+
+jobs:
+  test-job:
+    docker:
+      - image: cimg/base:stable
+    steps:
+      - run: echo "test"
+
+workflows:
+  test-workflow:
+    max_auto_reruns: << parameters.retries >>
+    jobs:
+      - test-job`,
+			OnlyErrors: true,
+			Diagnostics: []protocol.Diagnostic{
+				{
+					Range: protocol.Range{
+						Start: protocol.Position{Line: 11, Character: 21},
+						End:   protocol.Position{Line: 11, Character: 45},
+					},
+					Severity: protocol.DiagnosticSeverityError,
+					Source:   "cci-language-server",
+					Message:  "Parameter retries is not defined",
+					Data:     []protocol.CodeAction{},
+				},
+			},
+		},
 	}
 
 	CheckYamlErrors(t, testCases)

--- a/pkg/parser/workflows.go
+++ b/pkg/parser/workflows.go
@@ -94,9 +94,10 @@ func (doc *YamlDocument) parseSingleWorkflow(workflowNode *sitter.Node) ast.Work
 			res.Triggers = doc.parseWorkflowTriggers(valueNode)
 		case "max_auto_reruns":
 			res.MaxAutoRerunsRange = doc.NodeToRange(valueNode)
-			res.HasMaxAutoReruns = true
-			if valueText := doc.GetNodeText(valueNode); valueText != "" {
-				if maxAutoReruns, err := strconv.Atoi(valueText); err == nil {
+			rawText := doc.GetNodeText(valueNode)
+			if !utils.CheckIfOnlyParamUsed(rawText) {
+				res.HasMaxAutoReruns = true
+				if maxAutoReruns, err := strconv.Atoi(rawText); err == nil {
 					res.MaxAutoReruns = maxAutoReruns
 				}
 			}

--- a/pkg/parser/workflows.go
+++ b/pkg/parser/workflows.go
@@ -95,6 +95,11 @@ func (doc *YamlDocument) parseSingleWorkflow(workflowNode *sitter.Node) ast.Work
 		case "max_auto_reruns":
 			res.MaxAutoRerunsRange = doc.NodeToRange(valueNode)
 			rawText := doc.GetNodeText(valueNode)
+			// HasMaxAutoReruns means "present with a literal value", not merely
+			// "key present": it gates the 1-5 range check in validateSingleWorkflow.
+			// A parameter expression resolves at compile time, so leave it false to
+			// keep the range check from firing on the unresolved value. Undefined
+			// parameter names are still reported by CheckIfParamsExist.
 			if !utils.CheckIfOnlyParamUsed(rawText) {
 				res.HasMaxAutoReruns = true
 				if maxAutoReruns, err := strconv.Atoi(rawText); err == nil {

--- a/schema.json
+++ b/schema.json
@@ -1207,10 +1207,26 @@
                                             "$ref": "#/definitions/stepWhen"
                                         },
                                         "max_auto_reruns": {
-                                            "type": "integer",
-                                            "minimum": 1,
-                                            "maximum": 5,
-                                            "markdownDescription": "Maximum number of automatic reruns for this step"
+                                            "markdownDescription": "Maximum number of automatic reruns for this step. Can be an integer between 1 and 5, or a parameter expression.",
+                                            "anyOf": [
+                                                {
+                                                    "oneOf": [
+                                                        {
+                                                            "type": "string",
+                                                            "pattern": " *<< *parameters.([^ ]+) *>> *"
+                                                        },
+                                                        {
+                                                            "type": "string",
+                                                            "pattern": " *<< *pipeline.parameters.([^ ]+) *>> *"
+                                                        }
+                                                    ]
+                                                },
+                                                {
+                                                    "type": "integer",
+                                                    "minimum": 1,
+                                                    "maximum": 5
+                                                }
+                                            ]
                                         },
                                         "auto_rerun_delay": {
                                             "type": "string",
@@ -2361,10 +2377,26 @@
                         "markdownDescription": "Specifies which triggers will cause this workflow to be executed. Default behavior is to trigger the workflow when pushing to a branch."
                     },
                     "max_auto_reruns": {
-                        "type": "integer",
-                        "minimum": 1,
-                        "maximum": 5,
-                        "markdownDescription": "The maximum number of times a workflow will be automatically rerun if it fails"
+                        "markdownDescription": "The maximum number of times a workflow will be automatically rerun if it fails. Can be an integer between 1 and 5, or a parameter expression.",
+                        "anyOf": [
+                            {
+                                "oneOf": [
+                                    {
+                                        "type": "string",
+                                        "pattern": " *<< *parameters.([^ ]+) *>> *"
+                                    },
+                                    {
+                                        "type": "string",
+                                        "pattern": " *<< *pipeline.parameters.([^ ]+) *>> *"
+                                    }
+                                ]
+                            },
+                            {
+                                "type": "integer",
+                                "minimum": 1,
+                                "maximum": 5
+                            }
+                        ]
                     },
                     "when": {
                         "$ref": "#/definitions/logic",


### PR DESCRIPTION
Jira: https://circleci.atlassian.net/browse/PIPE-5463

# Description

Allow `max_auto_reruns` to accept parameter expressions (`<< parameters.x >>` / `<< pipeline.parameters.x >>`) in addition to integer values, at both the step and workflow level.

Currently, `max_auto_reruns` only accepts hardcoded integers (1-5). This change enables users to parameterize the value via orb parameters or pipeline parameters, matching the existing behavior of `parallelism`.

```
version: 2.1

jobs:
  test:
    docker:
      - image: cimg/base:stable
    parameters:
      retries:
        type: integer
        default: 3
    steps:
      - run:
          name: Run tests
          command: ./run-tests.sh
          max_auto_reruns: << parameters.retries >>

workflows:
  main:
    jobs:
      - test:
          retries: 2
```

# How to validate

1. Build and run tests:
```bash
docker run --rm -v $(pwd):/app -w /app golang:1.23 sh -c "gofmt -l pkg && go build ./... && go test ./... -count=1"
```

2. Verify that existing integer values (1-5) still validate correctly
3. Verify that `<< parameters.retries >>` and `<< pipeline.parameters.retries >>` are accepted without errors
4. Verify that invalid values (0, 6, random strings) still produce diagnostics