### PR TITLE
fix: gen2 resources

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -1865,11 +1865,11 @@
                                             "windows.gpu.nvidia.medium",
                                             "m4pro.medium",
                                             "m4pro.large",
-                                            "medium-gen2",
-                                            "large-gen2",
-                                            "xlarge-gen2",
-                                            "2xlarge-gen2",
-                                            "2xlarge+-gen2"
+                                            "medium.gen2",
+                                            "large.gen2",
+                                            "xlarge.gen2",
+                                            "2xlarge.gen2",
+                                            "2xlarge+.gen2"
                                         ]
                                     },
                                     {


### PR DESCRIPTION
Jira: No jira ticket exists

Github issue: https://github.com/CircleCI-Public/circleci-yaml-language-server/issues/415

**Important note** : Release-please will only create a release PR for releases with a `feat` or `fix` commit message. If your PR starts with `chore` , your changes will NOT be released.

# Description

> Fixes gen2 resource types to match what is allowed.

# Implementation details

Sample `.circleci/config.yml`, replace `medium-gen2` and `medium.gen2` as needed and push pipelines, the pipeline must be pushed up to circleci to perform a build as `circleci validate` does not suffice. See https://circleci.com/changelog/gen2-linux-vm-x86-remote-docker-resource-classes-now-generally-available/ for another reference to valid resource classes.

```yaml
  executors:
    go:
      docker:
        - image: cimg/go:1.26.2
       # resource_class: medium-gen2
✘     resource_class: medium.gen2     ● Value is not accepted. Valid values: "small", "medium", "medium+", "large", "xlarge", "2xlarge", "2xlarge+", "arm.medium", "arm.large", "arm.xlarge", "arm.2xlarge", "gpu.nvidia.small", "gpu.nvidia.medium", "windows.gpu.nvidia.medium", "m4pro.medi...

```

# How to validate

> Add steps to setup the extension and check that the PR works

