### PR TITLE
chore(ci): Mitigate Github rate limiting in "Create version file" job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -525,6 +525,8 @@ workflows:
       - Copy JSON schema
       - Create version file:
           is-prerelease: true
+          context:
+            - devex-release
       - Build Linux:
           name: Build Linux x86_64
           resource_class: medium
@@ -641,6 +643,8 @@ workflows:
       - Lint
       - Create version file:
           is-prerelease: true
+          context:
+            - devex-release
       - Build Linux:
           name: Build Linux arm64
           resource_class: arm.medium

--- a/scripts/get_next_release.go
+++ b/scripts/get_next_release.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"os"
 	"regexp"
 	"strconv"
 
@@ -27,7 +28,16 @@ type GithubRelease struct {
 }
 
 func getLatestVersion() string {
-	resp, err := http.Get("https://api.github.com/repos/CircleCI-Public/circleci-yaml-language-server/releases/latest")
+	req, err := http.NewRequest("GET", "https://api.github.com/repos/CircleCI-Public/circleci-yaml-language-server/releases/latest", nil)
+	if err != nil {
+		panic(err)
+	}
+
+	if token := os.Getenv("GITHUB_TOKEN"); token != "" {
+		req.Header.Set("Authorization", "token "+token)
+	}
+
+	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION



# Description

The Create version file jobs use a script `get_next_release.go`. This script makes an unauthenticated call to Github. This has resulted in countless job failures due to rate limiting:

- https://app.circleci.com/pipelines/gh/CircleCI-Public/circleci-yaml-language-server/1803/details?job=7053f591-f8c4-44de-8f67-94df5f9bcad9&buildNumber=11895&jobType=build&workflowId=1436dc26-d260-4481-9e5d-8caca3e5b180 
- https://app.circleci.com/pipelines/gh/CircleCI-Public/circleci-yaml-language-server/1803/details?job=9eae69db-6e01-4745-a132-a5443f5f256b&buildNumber=11892&jobType=build&workflowId=49dff0f1-5832-42a0-bbc4-05f0a2935a1f


We should use the existing `GITHUB_TOKEN` from the `devex-release` context so that we don't get rate limited. 

# Implementation details

- This updates the `get_next_release` script to actually use `GITHUB_TOKEN` token from env vars
- Also adds the devex-release context to the Create version file job invocations

# How to validate

CI passes!

