### PR TITLE
fix: address MELPA packaging requirements for circleci-yaml-mode

### DIFF
--- a/editors/emacs/circleci-yaml-mode.el
+++ b/editors/emacs/circleci-yaml-mode.el
@@ -1,14 +1,26 @@
 ;;; circleci-yaml-mode.el --- Major mode for CircleCI YAML config files -*- lexical-binding: t; -*-
 
-;; Copyright (C) 2025 CircleCI
-
 ;; Author: CircleCI
 ;; URL: https://github.com/CircleCI-Public/circleci-yaml-language-server
 ;; x-release-please-start-version
 ;; Version: 0.30.0
 ;; x-release-please-end
-;; Package-Requires: ((emacs "28.1") (yaml-mode "0.0.13"))
+;; Package-Requires: ((emacs "29.1") (yaml-mode "0.0.13"))
 ;; Keywords: languages tools
+
+;; Copyright (C) 2025 CircleCI
+
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+;; implied.  See the License for the specific language governing
+;; permissions and limitations under the License.
 
 ;;; Commentary:
 


### PR DESCRIPTION
## Background

The [MELPA recipe PR](https://github.com/melpa/melpa/pull/9951) for `circleci-yaml-mode` requires addressing several packaging quality checks before the recipe can be accepted.

## Proposed changes

- Add Apache 2.0 license boilerplate above `;;; Commentary:`, as required by [MELPA's contribution guidelines](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org#what-to-know-before-opening-a-pull-request)
- Bump minimum Emacs version from 28.1 to 29.1, since the package uses `eglot-current-server` which is part of the eglot library built-in from Emacs 29

## Verification

- `package-lint`: passes (4 advisory `with-eval-after-load` warnings for optional dependency integration, which is standard practice)
- Byte-compiles cleanly (only expected free-variable warnings for optional eglot/lsp-mode symbols)
- `checkdoc`: passes (2 advisory warnings for intentional `package: message` naming convention in error strings)
- Local MELPA build (`make recipes/circleci-yaml-mode`): produces valid package tarball

## What's the possible impact to customers?

Emacs users on version 28.x would no longer be able to use this package. However, eglot (the primary LSP client integration) is built-in from Emacs 29, so this reflects the practical minimum for the intended functionality.

## Deployment considerations

No deployment considerations. This only affects the Emacs package metadata.