### PR TITLE
feat: link to job-groups docs

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -2388,7 +2388,7 @@
             }
         },
         "job-groups": {
-            "markdownDescription": "Job groups define named collections of jobs with internal dependency relationships that can be referenced as a single unit in workflows.",
+            "markdownDescription": "https://circleci.com/docs/reference/configuration-reference/#job-groups\n\nJob groups define named collections of jobs with internal dependency relationships that can be referenced as a single unit in workflows.",
             "type": "object",
             "propertyNames": {
                 "type": "string",


### PR DESCRIPTION


# Description

We just released documentation for job groups to the CircleCI docs. Let's link to them in the hover for job-groups so users can find the link much easier.

https://circleci.com/docs/reference/configuration-reference/#job-groups


