### PR TITLE
feat: embed schema in binary to ease distribution

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -212,8 +212,6 @@ jobs:
             - version
 
   Unit Tests:
-    environment:
-      SCHEMA_LOCATION: /home/circleci/project/schema.json
     executor: go-executor
     parallelism: 5
     steps:
@@ -303,6 +301,9 @@ jobs:
           paths:
             - project/bin
 
+  # NOTE: The binary embeds the JSON schema, so this file is no longer
+  # required to run the language server. It is still bundled for editors
+  # (e.g. VS Code) that read the schema from disk for hover/validation.
   Copy JSON schema:
     docker:
       - image: cimg/base:stable

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -55,9 +55,7 @@
       "program": "${workspaceFolder}/cmd/start_server/start_server.go",
       "args": [
         "--port",
-        "10001",
-        "--schema",
-        "${workspaceFolder}/schema.json"
+        "10001"
       ]
     },
     {

--- a/ADD_A_CLIENT.md
+++ b/ADD_A_CLIENT.md
@@ -8,28 +8,18 @@ aware of.
 
 ### `schema.json`
 
-The Language Server (LS) needs the [`schema.json`](/schema.json) file to
-validate the YAMLs. To run the LS, you must have the file available locally and
-provide its path as `-schema` argument to the LS executable.
+The [`schema.json`](/schema.json) used for YAML validation is **embedded in the
+binary** at compile time. No external schema file is needed to run the language
+server.
 
-As the `schema.json` is versioned like the rest of the code, it is provided with
-every release, this means that when updating the LS binary should always come
-with an update of the `schema.json`.
+If you need to override the built-in schema (e.g., for development), you can
+pass `-schema /path/to/schema.json` to the LS executable. The schema file is
+also included in every GitHub release for reference.
 
 ### Hover
 
-The
-[`textDocument/hover`](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_hover)
-functionality is not actually implemented by the LS. Nevertheless, you will see
-reference to the functionality as it is implemented directly in the Typescript
-code of the VSCode extension. The functionality is provided thanks to the
-[SchemaStore JSON schema for CircleCI configs](https://github.com/SchemaStore/schemastore/blob/master/src/schemas/json/circleciconfig.json)
-that CircleCI help maintain and the
+The [`textDocument/hover`](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_hover) functionality is not yet implemented by the LS. The VS Code extension currently works around this by implementing hover hints client-side using the
 [vscode-json-languageservice](https://github.com/microsoft/vscode-json-languageservice).
-
-If you plan on implementing the feature you should look for a way to take
-advantage of this JSON and find an equivalent of `vscode-json-languageservice`
-that works for your editor.
 
 ### Configuration
 

--- a/HACKING.md
+++ b/HACKING.md
@@ -128,17 +128,28 @@ task prepare:vscode
    > [!NOTE]
    > Do not do `Run Extension (user extensions enabled)`. Running with no other extensions enabled
    > could cause confusion. Specifically, if you had the Red Hat YAML Language Server extension
-   > installed, it would display hover hints from the JSON schema from schemastore, rather than the local schema.json
+   > installed, it would display hover hints from the JSON schema from schemastore, rather than the local `schema.json`
    > that you will often be making changes to locally and want to test.
 
 ## Understanding the `schema.json` file
 
-The CircleCI YAML Language Server uses the standardized [JSON schema](https://json-schema.org/) to help perform basic structural validations and documentation hover hints the CircleCI YAML files. Our schema lives in `schema.json` and is utilized in multiple different places both inside and outside the codebase.
+The CircleCI YAML Language Server uses the standardized [JSON schema](https://json-schema.org/) to help perform basic structural validations on CircleCI YAML files. Our schema lives in `schema.json` at the repository root.
+
+### Embedded schema
+
+The schema is **embedded into the binary** at compile time using Go's `go:embed`
+directive (see `schema_embed.go`). This means the binary works standalone — no
+external files needed. You can override the built-in schema with the `-schema`
+flag or the `SCHEMA_LOCATION` environment variable for development purposes.
 
 ### Use Cases for `schema.json`
 
-- **External Tools**: This `schema.json` is notably used by the Red Hat YAML extension. Most VSCode users who open YAML files will have this extension installed. This extension by default will pull in schemas from [schemastore.org](https://www.schemastore.org/api/json/catalog.json). This extension on its own can detect if a user is reading a CircleCI config, then it will automatically pull in our `schema.json` by looking at schemastore, which in turn pulls the latest version of `schema.json` from the main branch of this repository.
-  - The Red Hat YAML language gets the schema.json from this URL: `https://raw.githubusercontent.com/CircleCI-Public/circleci-yaml-language-server/refs/heads/main/schema.json`
+- **Language Server Binary**: The Go binary embeds `schema.json` and uses it for
+  JSON schema validation of CircleCI configs. An override via `-schema` or
+  `SCHEMA_LOCATION` is supported but optional.
+
+- **External Tools**: The `schema.json` is used by the Red Hat YAML extension. Most VS Code users who open YAML files will have this extension installed. This extension by default will pull in schemas from [schemastore.org](https://www.schemastore.org/api/json/catalog.json). It can detect if a user is reading a CircleCI config and automatically pull in our `schema.json` from schemastore, which in turn pulls the latest version from the main branch of this repository.
+  - The Red Hat YAML language server gets the schema from: `https://raw.githubusercontent.com/CircleCI-Public/circleci-yaml-language-server/refs/heads/main/schema.json`
 
     > [!NOTE]
     > A user without the CircleCI VS Code extension installed, and just the Red Hat YAML language server
@@ -147,19 +158,15 @@ The CircleCI YAML Language Server uses the standardized [JSON schema](https://js
     > 1. schema validation
     > 2. a hover provider in VS Code for documentation hints
     >
-    > The benefit of installing the CircleCI Extension in VSCode is that it also pulls in the Go binary, providing more
+    > The benefit of installing the CircleCI Extension in VS Code is that it also pulls in the Go binary, providing more
     > complex validations against a user's CircleCI config that aren't possible with JSON Schema alone.
 
-- **CircleCI Go Language Server Binary**: The main language server reads this schema via the `SCHEMA_LOCATION` environment variable. The Go language server binary uses a JSON schema validation library and validates the config against the schema.
-  - As mentioned above, JSON Schema validation is also handled the Red Hat YAML language server. Our language server is intended to work standalone (but still be compatible with other language servers), so we also perform JSON schema validation in case the user only has our language server installed.
-  - Location: `pkg/services/diagnostics.go`, `pkg/services/validate.go`, etc.
+- **CircleCI VS Code Extension**: The closed-source VS Code extension implements
+  hover hints client-side by reading `schema.json` from disk
 
-- **CircleCI VSCode Extension**: CircleCI's closed-source VS Code extension will automatically pull in the latest version of the CircleCI language server from the GitHub releases page. The VS Code extension has some logic such that:
-  1. if it detects that the Red Hat YAML Language Server extension is not installed, it will register a hover provider
-     so that when the user hovers over the YAML code, it will provide hover hints from the `schema.json` it downloaded
-     from the CircleCI language server's releases page
-  2. if it detects the Red Hat YAML Language Server extension, it will defer the hover hints to the Red Hat
-     YAML Language Server, otherwise the user would see two instances of the hover hints.
-
-- **Go Tests**: Used for validation testing
+- **Go Tests**: Tests use the embedded schema by default. The file-based schema
+  can still be loaded explicitly for comparison tests.
   - Location: `pkg/services/diagnostics_test.go`
+
+- **GitHub Releases**: `schema.json` is included in every release for reference
+  and for tools that consume it directly.

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -60,7 +60,6 @@ tasks:
       - ./bin/start_server
     env:
       PORT: "{{.PORT | default 10001}}"
-      SCHEMA_LOCATION: ./schema.json
 
   init:
     - go mod download

--- a/cmd/parse_yaml/parse_yaml.go
+++ b/cmd/parse_yaml/parse_yaml.go
@@ -18,18 +18,14 @@ func main() {
 	// filepath := "examples/config1.yml"
 	// filepath := "/home/adib/circleci/circle/.circleci/config.yml"
 
-	schemaRef := flag.String("schema", "", "Location of the schema")
+	schemaRef := flag.String("schema", "", "Location of the schema (optional, uses built-in schema if not provided)")
 
 	flag.Parse()
 
+	// If no schema is provided via flag or env, the embedded schema will be used.
 	schema := *schemaRef
 	if schema == "" {
 		schema = os.Getenv("SCHEMA_LOCATION")
-
-		if schema == "" {
-			fmt.Print("No schema defined")
-			return
-		}
 	}
 
 	content, err := os.ReadFile(filepath)

--- a/cmd/start_server/start_server.go
+++ b/cmd/start_server/start_server.go
@@ -14,7 +14,7 @@ import (
 func main() {
 	hostRef := flag.String("host", "", "Hostname of the server")
 	portRef := flag.Int("port", -1, "port number")
-	schemaRef := flag.String("schema", "", "Location of the schema")
+	schemaRef := flag.String("schema", "", "Location of the schema (optional, uses built-in schema if not provided)")
 	versionRef := flag.Bool("version", false, "display version")
 	stdioRef := flag.Bool("stdio", false, "Use stdio instead of socket to communicate")
 	flag.Parse()
@@ -27,24 +27,20 @@ func main() {
 	}
 
 	// Parameter: schema
+	// If no schema is provided via flag or env, the embedded schema will be used.
 	schema := *schemaRef
 	if schema == "" {
 		schema = os.Getenv("SCHEMA_LOCATION")
+	}
 
-		if schema == "" {
-			fmt.Print("No schema defined")
-			return
+	if schema != "" && !path.IsAbs(schema) {
+		cwd, err := os.Getwd()
+
+		if err != nil {
+			fmt.Printf("Error while resolving schema path \"%s\"", schema)
+			panic(err)
 		}
-
-		if !path.IsAbs(schema) {
-			cwd, err := os.Getwd()
-
-			if err != nil {
-				fmt.Printf("Error while resolving schema path \"%s\"", schema)
-				panic(err)
-			}
-			schema = path.Join(cwd, schema)
-		}
+		schema = path.Join(cwd, schema)
 	}
 
 	// Command: stdio

--- a/editors/emacs/circleci-yaml-mode.el
+++ b/editors/emacs/circleci-yaml-mode.el
@@ -29,7 +29,7 @@
 ;;
 ;; Derives from `yaml-mode' and activates for files under .circleci/
 ;; directories.  On first use, downloads the CircleCI YAML Language
-;; Server binary and schema from GitHub releases.
+;; Server binary from GitHub releases.
 ;;
 ;; Works with both eglot (built-in from Emacs 29) and lsp-mode.
 ;; Whichever LSP client is loaded will be configured and started
@@ -85,7 +85,7 @@
 
 (defcustom circleci-yaml-lsp-install-dir
   (expand-file-name "circleci-yaml-lsp" user-emacs-directory)
-  "Directory where the language server binary and schema are installed."
+  "Directory where the language server binary is installed."
   :type 'directory)
 
 (defcustom circleci-yaml-api-token nil
@@ -133,10 +133,6 @@ is started when `circleci-yaml-mode' activates."
     (expand-file-name (concat "circleci-yaml-language-server" ext)
                       (expand-file-name "bin" circleci-yaml-lsp-install-dir))))
 
-(defun circleci-yaml--schema-path ()
-  "Return the path to schema.json."
-  (expand-file-name "schema.json" circleci-yaml-lsp-install-dir))
-
 (defun circleci-yaml--version-file ()
   "Return the path to the installed version marker file."
   (expand-file-name ".version" circleci-yaml-lsp-install-dir))
@@ -145,8 +141,7 @@ is started when `circleci-yaml-mode' activates."
 
 (defun circleci-yaml--installed-p ()
   "Return non-nil if the language server is installed."
-  (and (file-executable-p (circleci-yaml--lsp-bin))
-       (file-exists-p (circleci-yaml--schema-path))))
+  (file-executable-p (circleci-yaml--lsp-bin)))
 
 (defun circleci-yaml--installed-version ()
   "Return the installed version string, or nil."
@@ -173,11 +168,9 @@ is started when `circleci-yaml-mode' activates."
   "Download and install the CircleCI YAML Language Server."
   (interactive)
   (let ((bin (circleci-yaml--lsp-bin))
-        (schema (circleci-yaml--schema-path))
         (version-file (circleci-yaml--version-file)))
     (circleci-yaml--download (circleci-yaml--download-url (circleci-yaml--asset-name)) bin)
     (set-file-modes bin #o755)
-    (circleci-yaml--download (circleci-yaml--download-url "schema.json") schema)
     (with-temp-file version-file
       (insert circleci-yaml-lsp-version))
     (message "circleci-yaml-mode: installed v%s" circleci-yaml-lsp-version)))
@@ -207,7 +200,7 @@ automatically, downloading it on first use if needed.")
 
 (defun circleci-yaml--eglot-server-command ()
   "Return the eglot server command for the CircleCI YAML LS."
-  (list (circleci-yaml--lsp-bin) "-stdio" "-schema" (circleci-yaml--schema-path)))
+  (list (circleci-yaml--lsp-bin) "-stdio"))
 
 (with-eval-after-load 'eglot
   (add-to-list 'eglot-server-programs

--- a/editors/vscode/src/server.ts
+++ b/editors/vscode/src/server.ts
@@ -84,15 +84,8 @@ export class LSP {
   }
 
   private async spawnLSPServer(port: number): Promise<cp.ChildProcess> {
-    const inDevMode = isInDevMode();
-
-    const schemaLocation = inDevMode
-      ? this.context.asAbsolutePath(path.join("..", "..", "schema.json"))
-      : this.context.asAbsolutePath(path.join("schema.json"));
-
     const servProcess = cp.spawn(this.serverPath, [], {
       env: {
-        SCHEMA_LOCATION: schemaLocation,
         HOME: os.homedir(),
         PORT: port.toString(),
       },

--- a/pkg/parser/jsonschema.go
+++ b/pkg/parser/jsonschema.go
@@ -1,8 +1,6 @@
 package parser
 
 import (
-	"fmt"
-	"os"
 	"regexp"
 	"strconv"
 	"strings"
@@ -26,8 +24,19 @@ func (validator *JSONSchemaValidator) LoadJsonSchema(schemaLocation string) erro
 
 	schema, err := gojsonschema.NewSchema(loader)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error while loading JSON Schema \"%s\"\n", schemaLocation)
-		fmt.Fprintln(os.Stderr, err.Error())
+		return err
+	}
+
+	validator.schema = schema
+
+	return nil
+}
+
+func (validator *JSONSchemaValidator) LoadJsonSchemaFromBytes(data []byte) error {
+	loader := gojsonschema.NewBytesLoader(data)
+
+	schema, err := gojsonschema.NewSchema(loader)
+	if err != nil {
 		return err
 	}
 

--- a/pkg/parser/jsonschema_test.go
+++ b/pkg/parser/jsonschema_test.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 	"testing"
 
+	schema "github.com/CircleCI-Public/circleci-yaml-language-server"
 	"github.com/CircleCI-Public/circleci-yaml-language-server/pkg/expect"
 	"github.com/CircleCI-Public/circleci-yaml-language-server/pkg/testHelpers"
 	"github.com/stretchr/testify/assert"
@@ -293,8 +294,7 @@ jobs:
 					Doc: yamlDocument,
 				}
 
-				schemaPath := "../../schema.json"
-				err := validator.LoadJsonSchema(schemaPath)
+				err := validator.LoadJsonSchemaFromBytes(schema.EmbeddedSchemaJSON)
 				if err != nil {
 					t.Logf("Warning: Could not load schema: %v", err)
 					t.SkipNow()

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -134,7 +134,11 @@ func StartServer(port int, host string, schemaLocation string) {
 	go func() {
 		time.Sleep(1 * time.Second)
 		fmt.Printf("Server started on port %d, version %s\n", port, utils.ServerVersion)
-		fmt.Printf("   JSON Schema: %s", schemaLocation)
+		if schemaLocation != "" {
+			fmt.Printf("   JSON Schema: %s\n", schemaLocation)
+		} else {
+			fmt.Println("   JSON Schema: (embedded)")
+		}
 	}()
 
 	err = jsonrpc2.Serve(ctx, ln, server, 0)

--- a/pkg/services/background_auto_rerun_test.go
+++ b/pkg/services/background_auto_rerun_test.go
@@ -1,8 +1,6 @@
 package languageservice
 
 import (
-	"os"
-	"path/filepath"
 	"testing"
 
 	"github.com/CircleCI-Public/circleci-yaml-language-server/pkg/testHelpers"
@@ -12,9 +10,6 @@ import (
 )
 
 func TestBackgroundAutoRerunValidation(t *testing.T) {
-	cwd, _ := os.Getwd()
-	schemaPath, _ := filepath.Abs(cwd + "/../../schema.json")
-	os.Setenv("SCHEMA_LOCATION", schemaPath)
 	cache := utils.CreateCache()
 	context := testHelpers.GetDefaultLsContext()
 	context.Api.Token = ""
@@ -541,7 +536,7 @@ workflows:
 				EnvVariables: make([]string, 0),
 			})
 
-			diagnostics, err := DiagnosticFile(testUri, cache, context, schemaPath)
+			diagnostics, err := DiagnosticFile(testUri, cache, context, "")
 			if err != nil {
 				t.Errorf("DiagnosticFile failed: %v", err)
 				return

--- a/pkg/services/complete_test.go
+++ b/pkg/services/complete_test.go
@@ -3,7 +3,6 @@ package languageservice
 import (
 	"os"
 	"path"
-	"path/filepath"
 	"reflect"
 	"sort"
 	"testing"
@@ -18,9 +17,6 @@ import (
 )
 
 func TestComplete(t *testing.T) {
-	cwd, _ := os.Getwd()
-	schemaPath, _ := filepath.Abs(cwd + "/../../schema.json")
-	os.Setenv("SCHEMA_LOCATION", schemaPath)
 	cache := utils.CreateCache()
 
 	context := testHelpers.GetDefaultLsContext()

--- a/pkg/services/definition_test.go
+++ b/pkg/services/definition_test.go
@@ -3,7 +3,6 @@ package languageservice
 import (
 	"os"
 	"path"
-	"path/filepath"
 	"reflect"
 	"testing"
 
@@ -18,9 +17,6 @@ import (
 )
 
 func TestDefinition(t *testing.T) {
-	cwd, _ := os.Getwd()
-	schemaPath, _ := filepath.Abs(cwd + "/../../schema.json")
-	os.Setenv("SCHEMA_LOCATION", schemaPath)
 	cache := utils.CreateCache()
 
 	context := testHelpers.GetDefaultLsContext()

--- a/pkg/services/diagnostics.go
+++ b/pkg/services/diagnostics.go
@@ -7,6 +7,8 @@ import (
 	yamlparser "github.com/CircleCI-Public/circleci-yaml-language-server/pkg/parser"
 	"github.com/CircleCI-Public/circleci-yaml-language-server/pkg/parser/validate"
 	"github.com/CircleCI-Public/circleci-yaml-language-server/pkg/utils"
+
+	schema "github.com/CircleCI-Public/circleci-yaml-language-server"
 	"go.lsp.dev/protocol"
 	"go.lsp.dev/uri"
 )
@@ -66,7 +68,13 @@ func DiagnosticYAML(yamlDocument yamlparser.YamlDocument, cache *utils.Cache, co
 	validator := yamlparser.JSONSchemaValidator{
 		Doc: yamlDocument,
 	}
-	err := validator.LoadJsonSchema(yamlDocument.SchemaLocation)
+
+	var err error
+	if yamlDocument.SchemaLocation != "" {
+		err = validator.LoadJsonSchema(yamlDocument.SchemaLocation)
+	} else {
+		err = validator.LoadJsonSchemaFromBytes(schema.EmbeddedSchemaJSON)
+	}
 
 	if err != nil {
 		return []protocol.Diagnostic{}, err

--- a/pkg/services/diagnostics_test.go
+++ b/pkg/services/diagnostics_test.go
@@ -13,9 +13,6 @@ import (
 )
 
 func TestFindErrors(t *testing.T) {
-	cwd, _ := os.Getwd()
-	schemaPath, _ := filepath.Abs(cwd + "/../../schema.json")
-	os.Setenv("SCHEMA_LOCATION", schemaPath)
 	cache := utils.CreateCache()
 
 	type args struct {
@@ -57,7 +54,7 @@ func TestFindErrors(t *testing.T) {
 			context := testHelpers.GetDefaultLsContext()
 			context.Api.Token = ""
 			fileUri := uri.File(tt.args.filePath)
-			diagnostics, err := DiagnosticFile(fileUri, cache, context, schemaPath)
+			diagnostics, err := DiagnosticFile(fileUri, cache, context, "")
 
 			if err != nil {
 				t.Error("findErrors()", err)
@@ -65,6 +62,111 @@ func TestFindErrors(t *testing.T) {
 
 			if !reflect.DeepEqual(diagnostics, tt.want) {
 				t.Errorf("FindErrors() in file %s = %v, want %v", tt.args.filePath, diagnostics, tt.want)
+			}
+		})
+	}
+}
+
+func TestFindErrorsWithEmbeddedSchema(t *testing.T) {
+	cache := utils.CreateCache()
+
+	tests := []struct {
+		name     string
+		filePath string
+		want     []protocol.Diagnostic
+	}{
+		{
+			name:     "No errors with embedded schema",
+			filePath: "./testdata/noErrors.yml",
+			want:     make([]protocol.Diagnostic, 0),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			content, _ := os.ReadFile(tt.filePath)
+			cache.FileCache.SetFile(utils.CachedFile{
+				TextDocument: protocol.TextDocumentItem{
+					URI:  uri.File(tt.filePath),
+					Text: string(content),
+				},
+				Project:      utils.Project{},
+				EnvVariables: make([]string, 0),
+			})
+			context := testHelpers.GetDefaultLsContext()
+			context.Api.Token = ""
+			fileUri := uri.File(tt.filePath)
+
+			// Pass empty schemaLocation to exercise the embedded schema fallback
+			diagnostics, err := DiagnosticFile(fileUri, cache, context, "")
+
+			if err != nil {
+				t.Fatalf("DiagnosticFile() with embedded schema returned error: %v", err)
+			}
+
+			if !reflect.DeepEqual(diagnostics, tt.want) {
+				t.Errorf("DiagnosticFile() with embedded schema in file %s = %v, want %v", tt.filePath, diagnostics, tt.want)
+			}
+		})
+	}
+}
+
+func TestOverrideSchemaMatchesEmbeddedSchema(t *testing.T) {
+	cwd, _ := os.Getwd()
+	schemaPath := filepath.Join(cwd, "..", "..", "schema.json")
+
+	tests := []struct {
+		name           string
+		filePath       string
+		expectNonEmpty bool
+	}{
+		{
+			name:           "Clean file produces no diagnostics from either schema",
+			filePath:       "./testdata/noErrors.yml",
+			expectNonEmpty: false,
+		},
+		{
+			name:           "File with schema error produces matching diagnostics",
+			filePath:       "./testdata/schemaError.yml",
+			expectNonEmpty: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cache := utils.CreateCache()
+			content, err := os.ReadFile(tt.filePath)
+			if err != nil {
+				t.Fatalf("failed to read test file %s: %v", tt.filePath, err)
+			}
+			cache.FileCache.SetFile(utils.CachedFile{
+				TextDocument: protocol.TextDocumentItem{
+					URI:  uri.File(tt.filePath),
+					Text: string(content),
+				},
+				Project:      utils.Project{},
+				EnvVariables: make([]string, 0),
+			})
+			context := testHelpers.GetDefaultLsContext()
+			context.Api.Token = ""
+			fileUri := uri.File(tt.filePath)
+
+			fileDiags, err := DiagnosticFile(fileUri, cache, context, schemaPath)
+			if err != nil {
+				t.Fatalf("DiagnosticFile() with file schema returned error: %v", err)
+			}
+
+			embeddedDiags, err := DiagnosticFile(fileUri, cache, context, "")
+			if err != nil {
+				t.Fatalf("DiagnosticFile() with embedded schema returned error: %v", err)
+			}
+
+			if tt.expectNonEmpty && len(fileDiags) == 0 {
+				t.Error("expected diagnostics from file schema but got none")
+			}
+
+			if !reflect.DeepEqual(fileDiags, embeddedDiags) {
+				t.Errorf("Override schema produced different diagnostics than embedded schema.\nFile: %v\nEmbedded: %v", fileDiags, embeddedDiags)
 			}
 		})
 	}

--- a/pkg/services/references_test.go
+++ b/pkg/services/references_test.go
@@ -2,7 +2,6 @@ package languageservice
 
 import (
 	"os"
-	"path/filepath"
 	"reflect"
 	"sort"
 	"testing"
@@ -14,9 +13,6 @@ import (
 )
 
 func TestReferences(t *testing.T) {
-	cwd, _ := os.Getwd()
-	schemaPath, _ := filepath.Abs(cwd + "/../../schema.json")
-	os.Setenv("SCHEMA_LOCATION", schemaPath)
 	cache := utils.CreateCache()
 
 	type args struct {

--- a/pkg/services/testdata/schemaError.yml
+++ b/pkg/services/testdata/schemaError.yml
@@ -1,0 +1,14 @@
+version: true
+
+jobs:
+  build:
+    docker:
+      - image: cimg/node:20.0.0
+    steps:
+      - checkout
+      - run: echo "hello world"
+
+workflows:
+  test:
+    jobs:
+      - build

--- a/schema_embed.go
+++ b/schema_embed.go
@@ -1,0 +1,9 @@
+package schema
+
+import _ "embed"
+
+// EmbeddedSchemaJSON contains the built-in schema.json, embedded at compile time.
+// This allows the binary to work without requiring a separate schema file.
+//
+//go:embed schema.json
+var EmbeddedSchemaJSON []byte


### PR DESCRIPTION
# Description

Addresses https://github.com/CircleCI-Public/circleci-yaml-language-server/issues/353.

People looking to add the CircleCI language server to their editors, agent harnesses, or even just run it in the terminal needed to:

1. download the binary from the releases page
2. download the `schema.json` from releases page
3. run the server, passing in `-schema /path/to/schema`.

That's silly! Let's embed the schema in the binary so integrators don't need to think about this extra step.


# Implementation details

The schema is embedded into the binary at compile time using Go's `go:embed` directive (`schema_embed.go` at the repo root). A new `LoadJsonSchemaFromBytes` method on `JSONSchemaValidator` loads the schema from the embedded bytes using `gojsonschema.NewBytesLoader`. The diagnostics code (`pkg/services/diagnostics.go`) checks if `SchemaLocation` is empty. If so, it uses the embedded schema; otherwise it loads from the provided path as before.

Both CLI entry points (`cmd/start_server`, `cmd/parse_yaml`) no longer exit when no schema is provided. The `-schema` flag and `SCHEMA_LOCATION` env var still work as overrides.

Editor clients were updated to stop passing the schema:
- Emacs: removed schema download, removed `-schema` from the server command
- VS Code (dev extension): removed `SCHEMA_LOCATION` from the spawn env

Test files were updated to pass `""` as the schema location (using the embedded fallback) and unused filepath/os imports were cleaned up. 

The CI config, Taskfile, and VS Code launch config were updated to remove SCHEMA_LOCATION/-schema where no longer needed.

# Future Work

- Incorporate hover back into this language server so that editors don't need to do hover themselves. (i.e. our official and dev VSCode extension using the schema.json file for hover capability)
- Update the CCI VSCode extension to stop passing the `-schema` flag

# How to validate

Build and verify the server starts without the `-schema` arg:

```
go build -o /tmp/circleci-lsp ./cmd/start_server
/tmp/circleci-lsp -version
# previously this would print "No schema defined" and exit:
/tmp/circleci-lsp -stdio  # should start the LSP (ctrl-c to stop)

# verify -schema override still works
/tmp/circleci-lsp -stdio -schema ./schema.json
# verify help text shows schema is optional
/tmp/circleci-lsp -help
```

Running the local VSCode dev extension without the schema flag passed:


https://github.com/user-attachments/assets/6b82c48c-ccf4-461b-a07f-50b7f2168e43