### PR TITLE
fix(WEBEX-208): context validation (API errors and context name lookup)

### DIFF
--- a/pkg/parser/validate/job_invocation.go
+++ b/pkg/parser/validate/job_invocation.go
@@ -254,7 +254,11 @@ func (val Validate) validateSingleJobInvocation(jobInvocation ast.JobInvocation,
 	if cachedFile := val.Cache.FileCache.GetFile(val.Doc.URI); val.Context.Api.Token != "" &&
 		cachedFile != nil && cachedFile.Project.OrganizationName != "" {
 		for _, context := range jobInvocation.Context {
-			if context.Text != "org-global" && val.Cache.ContextCache.GetOrganizationContext(cachedFile.Project.OrganizationId, context.Text) == nil {
+			if context.Text != "org-global" && val.Cache.ContextCache.ResolveWorkflowContext(
+				cachedFile.Project.OrganizationId,
+				cachedFile.Project.OrganizationSlug,
+				context.Text,
+			) == nil {
 				val.addDiagnostic(utils.CreateErrorDiagnosticFromRange(
 					context.Range,
 					fmt.Sprintf("Context %s does not exist", context.Text)))

--- a/pkg/utils/cache.go
+++ b/pkg/utils/cache.go
@@ -62,8 +62,9 @@ type OrbCache struct {
 }
 
 type ContextCache struct {
-	cacheMutex   *sync.Mutex
-	contextCache map[string]map[string]*Context
+	cacheMutex            *sync.Mutex
+	contextCache          map[string]map[string]*Context
+	ambiguousShortNames   map[string]map[string]struct{}
 }
 
 type ResourceClassCache struct {
@@ -86,6 +87,7 @@ func (c *Cache) init() {
 
 	c.ContextCache.cacheMutex = &sync.Mutex{}
 	c.ContextCache.contextCache = make(map[string]map[string]*Context)
+	c.ContextCache.ambiguousShortNames = make(map[string]map[string]struct{})
 
 	c.ResourceClassCache.cacheMutex = &sync.Mutex{}
 	c.ResourceClassCache.resourceClassCache = make(map[protocol.URI]*[]string)
@@ -288,16 +290,41 @@ func (c *ContextCache) SetOrganizationContext(organizationId string, ctx *Contex
 	orgMap := c.contextCache[organizationId]
 	orgMap[ctx.Name] = ctx
 	// CircleCI configs often use the short context name for the project's org; the API may
-	// return a qualified name (org/context). Also index by the suffix so lookups match.
+	// return a qualified name (org/context). Also index by the suffix when unambiguous.
 	if i := strings.LastIndex(ctx.Name, "/"); i >= 0 {
 		short := ctx.Name[i+1:]
-		if short != "" && short != ctx.Name {
-			if _, exists := orgMap[short]; !exists {
-				orgMap[short] = ctx
-			}
+		if short == "" {
+			return ctx
 		}
+		if c.isAmbiguousShortName(organizationId, short) {
+			return ctx
+		}
+		if existing, exists := orgMap[short]; exists {
+			if existing != ctx {
+				delete(orgMap, short)
+				c.markAmbiguousShortName(organizationId, short)
+			}
+			return ctx
+		}
+		orgMap[short] = ctx
 	}
 	return ctx
+}
+
+func (c *ContextCache) isAmbiguousShortName(organizationId, short string) bool {
+	ambiguous, ok := c.ambiguousShortNames[organizationId]
+	if !ok {
+		return false
+	}
+	_, ok = ambiguous[short]
+	return ok
+}
+
+func (c *ContextCache) markAmbiguousShortName(organizationId, short string) {
+	if c.ambiguousShortNames[organizationId] == nil {
+		c.ambiguousShortNames[organizationId] = make(map[string]struct{})
+	}
+	c.ambiguousShortNames[organizationId][short] = struct{}{}
 }
 
 func (c *ContextCache) GetOrganizationContext(organizationId string, name string) *Context {

--- a/pkg/utils/cache.go
+++ b/pkg/utils/cache.go
@@ -62,9 +62,9 @@ type OrbCache struct {
 }
 
 type ContextCache struct {
-	cacheMutex            *sync.Mutex
-	contextCache          map[string]map[string]*Context
-	ambiguousShortNames   map[string]map[string]struct{}
+	cacheMutex          *sync.Mutex
+	contextCache        map[string]map[string]*Context
+	ambiguousShortNames map[string]map[string]struct{}
 }
 
 type ResourceClassCache struct {

--- a/pkg/utils/cache.go
+++ b/pkg/utils/cache.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path"
 	"slices"
+	"strings"
 	"sync"
 
 	"github.com/CircleCI-Public/circleci-yaml-language-server/pkg/ast"
@@ -284,7 +285,18 @@ func (c *ContextCache) SetOrganizationContext(organizationId string, ctx *Contex
 	if c.contextCache[organizationId] == nil {
 		c.contextCache[organizationId] = make(map[string]*Context)
 	}
-	c.contextCache[organizationId][ctx.Name] = ctx
+	orgMap := c.contextCache[organizationId]
+	orgMap[ctx.Name] = ctx
+	// CircleCI configs often use the short context name for the project's org; the API may
+	// return a qualified name (org/context). Also index by the suffix so lookups match.
+	if i := strings.LastIndex(ctx.Name, "/"); i >= 0 {
+		short := ctx.Name[i+1:]
+		if short != "" && short != ctx.Name {
+			if _, exists := orgMap[short]; !exists {
+				orgMap[short] = ctx
+			}
+		}
+	}
 	return ctx
 }
 
@@ -292,6 +304,34 @@ func (c *ContextCache) GetOrganizationContext(organizationId string, name string
 	c.cacheMutex.Lock()
 	defer c.cacheMutex.Unlock()
 	return c.contextCache[organizationId][name]
+}
+
+// ResolveWorkflowContext looks up a context as referenced in config: exact key, then common
+// alternates between short vs org-qualified names (API and config do not always agree).
+func (c *ContextCache) ResolveWorkflowContext(organizationId, organizationSlug, workflowContextName string) *Context {
+	c.cacheMutex.Lock()
+	defer c.cacheMutex.Unlock()
+	org := c.contextCache[organizationId]
+	if org == nil {
+		return nil
+	}
+	if ctx := org[workflowContextName]; ctx != nil {
+		return ctx
+	}
+	if i := strings.LastIndex(workflowContextName, "/"); i >= 0 {
+		short := workflowContextName[i+1:]
+		if short != "" {
+			if ctx := org[short]; ctx != nil {
+				return ctx
+			}
+		}
+	}
+	if organizationSlug != "" && !strings.Contains(workflowContextName, "/") {
+		if ctx := org[organizationSlug+"/"+workflowContextName]; ctx != nil {
+			return ctx
+		}
+	}
+	return nil
 }
 
 func (c *ContextCache) RemoveOrganizationContext(organizationId string, name string) {

--- a/pkg/utils/cache_test.go
+++ b/pkg/utils/cache_test.go
@@ -1,0 +1,88 @@
+package utils
+
+import "testing"
+
+func testContext(name string) *Context {
+	return &Context{Name: name}
+}
+
+func TestContextCache_ResolveWorkflowContext(t *testing.T) {
+	orgID := "org-uuid"
+	orgSlug := "my-org"
+
+	cache := CreateCache()
+	cache.ContextCache.SetOrganizationContext(orgID, testContext("my-org/deploy"))
+	cache.ContextCache.SetOrganizationContext(orgID, testContext("my-org/staging"))
+
+	tests := []struct {
+		name                string
+		workflowContextName string
+		organizationSlug    string
+		wantName            string
+	}{
+		{
+			name:                "exact match",
+			workflowContextName: "my-org/deploy",
+			wantName:            "my-org/deploy",
+		},
+		{
+			name:                "suffix match",
+			workflowContextName: "deploy",
+			wantName:            "my-org/deploy",
+		},
+		{
+			name:                "org-slug-prefix match",
+			workflowContextName: "staging",
+			organizationSlug:    orgSlug,
+			wantName:            "my-org/staging",
+		},
+		{
+			name:                "no match",
+			workflowContextName: "missing",
+			wantName:            "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := cache.ContextCache.ResolveWorkflowContext(orgID, tt.organizationSlug, tt.workflowContextName)
+			if tt.wantName == "" {
+				if got != nil {
+					t.Fatalf("ResolveWorkflowContext() = %q, want nil", got.Name)
+				}
+				return
+			}
+			if got == nil {
+				t.Fatalf("ResolveWorkflowContext() = nil, want %q", tt.wantName)
+			}
+			if got.Name != tt.wantName {
+				t.Fatalf("ResolveWorkflowContext() = %q, want %q", got.Name, tt.wantName)
+			}
+		})
+	}
+}
+
+func TestContextCache_SetOrganizationContext_shortNameCollision(t *testing.T) {
+	orgID := "org-uuid"
+	cache := CreateCache()
+
+	cache.ContextCache.SetOrganizationContext(orgID, testContext("org-a/deploy"))
+	cache.ContextCache.SetOrganizationContext(orgID, testContext("org-b/deploy"))
+
+	if got := cache.ContextCache.GetOrganizationContext(orgID, "deploy"); got != nil {
+		t.Fatalf("short key should be dropped after collision, got %q", got.Name)
+	}
+
+	if got := cache.ContextCache.ResolveWorkflowContext(orgID, "org-a", "deploy"); got == nil || got.Name != "org-a/deploy" {
+		t.Fatalf("org-slug lookup should still resolve org-a/deploy, got %#v", got)
+	}
+
+	if got := cache.ContextCache.ResolveWorkflowContext(orgID, "", "deploy"); got != nil {
+		t.Fatalf("ambiguous short name should not resolve without org slug, got %q", got.Name)
+	}
+
+	cache.ContextCache.SetOrganizationContext(orgID, testContext("org-c/deploy"))
+	if got := cache.ContextCache.GetOrganizationContext(orgID, "deploy"); got != nil {
+		t.Fatalf("short key should stay dropped after later collision, got %q", got.Name)
+	}
+}

--- a/pkg/utils/context.go
+++ b/pkg/utils/context.go
@@ -100,13 +100,19 @@ func getContext(lsContext *LsContext, orgID string, nextPageToken string) (*GetA
 	if err != nil {
 		return nil, err
 	}
-
 	defer res.Body.Close()
-	defer io.Copy(io.Discard, res.Body)
+
+	body, err := io.ReadAll(res.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	if res.StatusCode < 200 || res.StatusCode >= 300 {
+		return nil, fmt.Errorf("list contexts (owner-id=%s): HTTP %d: %s", orgID, res.StatusCode, string(body))
+	}
 
 	var resp GetAllContextRes
-	err = json.NewDecoder(res.Body).Decode(&resp)
-	if err != nil {
+	if err = json.Unmarshal(body, &resp); err != nil {
 		return nil, err
 	}
 

--- a/pkg/utils/context_test.go
+++ b/pkg/utils/context_test.go
@@ -1,0 +1,98 @@
+package utils
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+func Test_getContext(t *testing.T) {
+	orgID := "11111111-2222-3333-4444-555555555555"
+	createdAt := time.Date(2024, 1, 2, 3, 4, 5, 0, time.UTC)
+
+	tests := []struct {
+		name       string
+		statusCode int
+		body       string
+		wantErr    string
+		wantItems  int
+	}{
+		{
+			name:       "success",
+			statusCode: http.StatusOK,
+			body: `{
+				"items": [{
+					"name": "my-org/deploy",
+					"id": "ctx-id",
+					"created_at": "2024-01-02T03:04:05Z",
+					"environment_variables": []
+				}]
+			}`,
+			wantItems: 1,
+		},
+		{
+			name:       "unauthorized",
+			statusCode: http.StatusUnauthorized,
+			body:       `{"message":"Unauthorized"}`,
+			wantErr:    "HTTP 401",
+		},
+		{
+			name:       "invalid json on success status",
+			statusCode: http.StatusOK,
+			body:       `{`,
+			wantErr:    "unexpected end of JSON input",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if got := r.Header.Get("Circle-Token"); got != "test-token" {
+					t.Errorf("Circle-Token = %q, want %q", got, "test-token")
+				}
+				if !strings.Contains(r.URL.Path, "/api/v2/context") {
+					t.Fatalf("unexpected path: %s", r.URL.Path)
+				}
+				if got := r.URL.Query().Get("owner-id"); got != orgID {
+					t.Fatalf("owner-id = %q, want %q", got, orgID)
+				}
+
+				w.WriteHeader(tt.statusCode)
+				_, _ = w.Write([]byte(tt.body))
+			}))
+			defer server.Close()
+
+			lsContext := &LsContext{
+				Api: ApiContext{
+					Token:   "test-token",
+					HostUrl: server.URL,
+				},
+			}
+
+			got, err := getContext(lsContext, orgID, "")
+			if tt.wantErr != "" {
+				if err == nil {
+					t.Fatalf("getContext() error = nil, want error containing %q", tt.wantErr)
+				}
+				if !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("getContext() error = %q, want containing %q", err.Error(), tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("getContext() unexpected error: %v", err)
+			}
+			if len(got.Items) != tt.wantItems {
+				t.Fatalf("len(Items) = %d, want %d", len(got.Items), tt.wantItems)
+			}
+			if got.Items[0].Name != "my-org/deploy" {
+				t.Fatalf("Items[0].Name = %q, want %q", got.Items[0].Name, "my-org/deploy")
+			}
+			if !got.Items[0].CreatedAt.Equal(createdAt) {
+				t.Fatalf("Items[0].CreatedAt = %v, want %v", got.Items[0].CreatedAt, createdAt)
+			}
+		})
+	}
+}

--- a/pkg/utils/git.go
+++ b/pkg/utils/git.go
@@ -83,7 +83,10 @@ func GetProjectOrg(projectSlug string) string {
 func GetProjectId(projectSlug string, lsContext *LsContext) (Project, error) {
 	url := fmt.Sprintf("%s/api/v2/project/%s", lsContext.Api.HostUrl, projectSlug)
 
-	req, _ := http.NewRequest("GET", url, nil)
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return Project{}, err
+	}
 
 	req.Header.Add("Circle-Token", lsContext.Api.Token)
 	req.Header.Set("User-Agent", UserAgent)
@@ -98,6 +101,10 @@ func GetProjectId(projectSlug string, lsContext *LsContext) (Project, error) {
 	body, err := io.ReadAll(res.Body)
 	if err != nil {
 		return Project{}, err
+	}
+
+	if res.StatusCode < 200 || res.StatusCode >= 300 {
+		return Project{}, fmt.Errorf("get project %q: HTTP %d: %s", projectSlug, res.StatusCode, string(body))
 	}
 
 	var projectIdRes Project


### PR DESCRIPTION
## Summary
Context diagnostics (`Context X does not exist`) could appear when the CircleCI API had not actually returned a successful context list, or when config used a short context name while the list-contexts API returned a qualified name (or the reverse).

## Changes
- **`getContext`**: require HTTP 2xx and read the body before JSON decode; return a clear error on failure instead of treating error bodies as empty results.
- **`GetProjectId`**: same for project fetch; handle `http.NewRequest` errors.
- **Context cache**: when storing a qualified API name (`org/context`), also index the short suffix when that key is free; **`ResolveWorkflowContext`** resolves exact, suffix-after-`/`, and `organizationSlug/short` forms.
- **Workflow validation**: use `ResolveWorkflowContext` instead of a single map lookup.

## Testing
`go test ./pkg/utils/... ./pkg/parser/validate/...`

---
Opened from fork: https://github.com/CircleCI-Support/circleci-yaml-language-server

Made with [Cursor](https://cursor.com)