### PR TITLE
feat: Add new Q2 2026 linux images

### DIFF
--- a/pkg/utils/executors.go
+++ b/pkg/utils/executors.go
@@ -36,6 +36,7 @@ var ValidLinuxImages = []string{
 	"ubuntu-2004:edge",
 
 	// Ubuntu 22.04
+	"ubuntu-2204:2026.05.1",
 	"ubuntu-2204:2025.09.1",
 	"ubuntu-2204:2024.11.1",
 	"ubuntu-2204:2024.08.1",
@@ -58,12 +59,17 @@ var ValidLinuxImages = []string{
 	"ubuntu-2204:edge",
 
 	// Ubuntu 24.04
+	"ubuntu-2404:2026.05.1",
 	"ubuntu-2404:2025.09.1",
 	"ubuntu-2404:2024.11.1",
 	"ubuntu-2404:2024.08.1",
 	"ubuntu-2404:2024.05.1",
 	"ubuntu-2404:current",
 	"ubuntu-2404:edge",
+
+	// Ubuntu 26.04
+	"ubuntu-2604:2026.05.1",
+	"ubuntu-2604:edge",
 
 	// Android
 	"android:2025.10.1",
@@ -102,6 +108,9 @@ var ValidLinuxGen2Images = []string{
 	// Ubuntu 24.04
 	"ubuntu-2404:current",
 	"ubuntu-2404:edge",
+
+	// Ubuntu 26.04
+	"ubuntu-2604:edge",
 }
 
 var ValidLinuxResourceClasses = []string{


### PR DESCRIPTION
# Description
This PR adds new Linux images for 2026 Q2:
- https://circleci.com/developer/machine/image/ubuntu-2204
- https://circleci.com/developer/machine/image/ubuntu-2404
- https://circleci.com/developer/machine/image/ubuntu-2604

New images added:
- `ubuntu-2204:2026.05.1`
- `ubuntu-2404:2026.05.1`
- `ubuntu-2604:2026.05.1` (new distro — Ubuntu 26.04 Resolute)
- `ubuntu-2604:edge`

# Implementation details
Added new images to existing arrays in `pkg/utils/executors.go`. Added new Ubuntu 26.04 section to both `ValidLinuxImages` and `ValidLinuxGen2Images`.

# How to validate
Here's a quick usage example:
```yaml
version: 2.1
jobs:
  build:
    machine:
      image: 'ubuntu-2604:2026.05.1'
      resource_class: medium
    steps:
      - run: echo 'Hello World'
```