### PR TITLE
feat: Add new Q2 2026 Android and Windows images

### DIFF
--- a/pkg/utils/executors.go
+++ b/pkg/utils/executors.go
@@ -72,6 +72,7 @@ var ValidLinuxImages = []string{
 	"ubuntu-2604:edge",
 
 	// Android
+	"android:2026.05.1",
 	"android:2025.10.1",
 	"android:2024.11.1",
 	"android:2024.04.1",
@@ -152,6 +153,7 @@ var ValidWindowsImages = []string{
 	"windows-server-2019-vs2019:edge",
 
 	// Windows Server 2022
+	"windows-server-2022-gui:2026.05.1",
 	"windows-server-2022-gui:2025.10.1",
 	"windows-server-2022-gui:2024.12.1",
 	"windows-server-2022-gui:2024.04.1",
@@ -173,6 +175,7 @@ var ValidWindowsImages = []string{
 	"windows-server-2022-gui:edge",
 
 	// Windows Server 2025
+	"windows-server-2025-gui:2026.05.1",
 	"windows-server-2025-gui:2025.10.1",
 	"windows-server-2025-gui:current",
 	"windows-server-2025-gui:edge",


### PR DESCRIPTION
# Description
This PR adds new Android and Windows images for 2026 Q2:
- https://circleci.com/developer/machine/image/android
- https://circleci.com/developer/machine/image/windows-server-2022-gui
- https://circleci.com/developer/machine/image/windows-server-2025-gui

New images added:
- `android:2026.05.1`
- `windows-server-2022-gui:2026.05.1`
- `windows-server-2025-gui:2026.05.1`

# Implementation details
Added new entries to the existing Android section of `ValidLinuxImages` and to the Windows Server 2022 and Windows Server 2025 sections of `ValidWindowsImages` in `pkg/utils/executors.go`.

The Windows CUDA variants (`windows-server-2022-cuda:2026.05.1`, `windows-server-2025-cuda:2026.05.1`) are not added here because `ValidWindowsGPUImages` only tracks the `:current` / `:edge` aliases — those will automatically resolve to the new dated tags once the customer-facing release is promoted.

# How to validate
Here's a quick usage example:
```yaml
version: 2.1
jobs:
  build-android:
    machine:
      image: 'android:2026.05.1'
      resource_class: medium
    steps:
      - run: echo 'Hello from Android'
  build-windows-2022:
    machine:
      image: 'windows-server-2022-gui:2026.05.1'
      resource_class: windows.medium
    steps:
      - run: echo 'Hello from Windows Server 2022'
  build-windows-2025:
    machine:
      image: 'windows-server-2025-gui:2026.05.1'
      resource_class: windows.medium
    steps:
      - run: echo 'Hello from Windows Server 2025'
```