### PR TITLE
ci: remove unnecessary build job from PR workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -644,13 +644,3 @@ workflows:
     jobs:
       - Unit Tests
       - Lint
-      - Create version file:
-          is-prerelease: true
-          context:
-            - devex-release
-      - Build Linux:
-          name: Build Linux arm64
-          resource_class: arm.medium
-          arch: arm64
-          requires:
-            - Create version file


### PR DESCRIPTION
The Build and test workflow (non-main branches) included a Create version file job and a Build Linux arm64 job. These are unnecessary for PR branches: the version file only exists to embed a version string into release binaries, which is meaningless for test builds.

Additionally, Create version file required the devex-release context which is now restricted to main, causing unauthorized errors on PR branches.

The workflow now only runs Unit Tests and Lint.


Note: this means branches will no longer try to build a binary.