### PR TITLE
chore: allow use of `CIRCLE_TOKEN` in dev extension + add docs

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -131,6 +131,32 @@ task prepare:vscode
    > installed, it would display hover hints from the JSON schema from schemastore, rather than the local `schema.json`
    > that you will often be making changes to locally and want to test.
 
+### Authentication / API token
+
+Some language server features require a CircleCI API token. For example,
+resolving private orbs, fetching contexts, and validating project-specific
+settings. The embedded VS Code extension reads the token from the environment
+and sends it to the running language server via the `setToken` LSP command
+immediately after the server initialises.
+
+Set `CIRCLE_TOKEN` before launching VS Code (the `TOKEN` environment variable
+is also accepted as a fallback):
+
+```bash
+export CIRCLE_TOKEN=<your-token>
+code .
+```
+
+If neither variable is set the extension starts without a token. The server
+still works, but features that call the CircleCI API will be unavailable.
+
+> [!NOTE]
+> This is how the **development** extension passes the token. Production
+> clients (e.g. the CircleCI VS Code marketplace extension) handle
+> authentication through their own UI flows and send the same `setToken`
+> command once the user has logged in. See `ADD_A_CLIENT.md` for details on
+> implementing this in other editors.
+
 ## Understanding the `schema.json` file
 
 The CircleCI YAML Language Server uses the standardized [JSON schema](https://json-schema.org/) to help perform basic structural validations on CircleCI YAML files. Our schema lives in `schema.json` at the repository root.

--- a/editors/vscode/src/server.ts
+++ b/editors/vscode/src/server.ts
@@ -198,7 +198,7 @@ export class LSP {
 
     await client.start();
 
-    const token = process.env.TOKEN;
+    const token = process.env.CIRCLE_TOKEN ?? process.env.TOKEN;
     const setTokenCommand = {
       command: "setToken",
       arguments: [token ?? ""],


### PR DESCRIPTION


# Description

While reviewing https://github.com/CircleCI-Public/circleci-yaml-language-server/pull/432 I didn't realize that my circle token was not being picked up by the dev extension. This functionality was not apparent. 

# Implementation details

The dev extension now looks for `CIRCLE_TOKEN` by default, with a fallback to the more generic `TOKEN` env var. Also added docs to explain how this works and what it is for.

# How to validate

Spin up vscode from the command line with `CIRCLE_TOKEN` set to a real token via env vars. See that it can now check what contexts the user has access to. 

