### PR TITLE
fix(WEBEX-208): list contexts without env vars for validation

### DIFF
--- a/pkg/parser/validate/job_invocation.go
+++ b/pkg/parser/validate/job_invocation.go
@@ -252,7 +252,8 @@ func (val Validate) validateSingleJobInvocation(jobInvocation ast.JobInvocation,
 	}
 
 	if cachedFile := val.Cache.FileCache.GetFile(val.Doc.URI); val.Context.Api.Token != "" &&
-		cachedFile != nil && cachedFile.Project.OrganizationName != "" {
+		cachedFile != nil && cachedFile.Project.OrganizationName != "" &&
+		val.Cache.ContextCache.IsOrganizationContextListLoaded(cachedFile.Project.OrganizationId) {
 		for _, context := range jobInvocation.Context {
 			if context.Text != "org-global" && val.Cache.ContextCache.ResolveWorkflowContext(
 				cachedFile.Project.OrganizationId,

--- a/pkg/server/methods/envVariables.go
+++ b/pkg/server/methods/envVariables.go
@@ -23,6 +23,12 @@ func (methods *Methods) getAllEnvVariables(textDocument protocol.TextDocumentIte
 	err := utils.GetAllContext(methods.LsContext, cachedFile.Project.OrganizationId, methods.Cache)
 	if err != nil {
 		log.Printf("error getting contexts: %s", err)
+		return
+	}
+	methods.Cache.ContextCache.MarkOrganizationContextListLoaded(cachedFile.Project.OrganizationId)
+
+	if err := utils.GetAllContextWithEnvVars(methods.LsContext, cachedFile.Project.OrganizationId, methods.Cache); err != nil {
+		log.Printf("error getting context environment variables: %s", err)
 	}
 }
 

--- a/pkg/utils/cache.go
+++ b/pkg/utils/cache.go
@@ -290,7 +290,6 @@ func (cache *Cache) clearContextCache() {
 	cache.ContextCache.listLoadedOrgs = make(map[string]bool)
 }
 
-
 func (c *ContextCache) MarkOrganizationContextListLoaded(organizationId string) {
 	c.cacheMutex.Lock()
 	defer c.cacheMutex.Unlock()

--- a/pkg/utils/cache.go
+++ b/pkg/utils/cache.go
@@ -65,6 +65,7 @@ type ContextCache struct {
 	cacheMutex          *sync.Mutex
 	contextCache        map[string]map[string]*Context
 	ambiguousShortNames map[string]map[string]struct{}
+	listLoadedOrgs      map[string]bool
 }
 
 type ResourceClassCache struct {
@@ -88,6 +89,7 @@ func (c *Cache) init() {
 	c.ContextCache.cacheMutex = &sync.Mutex{}
 	c.ContextCache.contextCache = make(map[string]map[string]*Context)
 	c.ContextCache.ambiguousShortNames = make(map[string]map[string]struct{})
+	c.ContextCache.listLoadedOrgs = make(map[string]bool)
 
 	c.ResourceClassCache.cacheMutex = &sync.Mutex{}
 	c.ResourceClassCache.resourceClassCache = make(map[protocol.URI]*[]string)
@@ -277,9 +279,40 @@ func GetOrbCacheFSPath(orbYaml string) string {
 func (cache *Cache) ClearHostData() {
 	cache.RemoveOrbFiles()
 	cache.OrbCache.RemoveOrbs()
+	cache.clearContextCache()
 }
 
-// Context cache
+func (cache *Cache) clearContextCache() {
+	cache.ContextCache.cacheMutex.Lock()
+	defer cache.ContextCache.cacheMutex.Unlock()
+	cache.ContextCache.contextCache = make(map[string]map[string]*Context)
+	cache.ContextCache.ambiguousShortNames = make(map[string]map[string]struct{})
+	cache.ContextCache.listLoadedOrgs = make(map[string]bool)
+}
+
+
+func (c *ContextCache) MarkOrganizationContextListLoaded(organizationId string) {
+	c.cacheMutex.Lock()
+	defer c.cacheMutex.Unlock()
+	if c.listLoadedOrgs == nil {
+		c.listLoadedOrgs = make(map[string]bool)
+	}
+	c.listLoadedOrgs[organizationId] = true
+}
+
+func (c *ContextCache) IsOrganizationContextListLoaded(organizationId string) bool {
+	c.cacheMutex.Lock()
+	defer c.cacheMutex.Unlock()
+	return c.listLoadedOrgs[organizationId]
+}
+
+func (c *ContextCache) ClearOrganizationContextList(organizationId string) {
+	c.cacheMutex.Lock()
+	defer c.cacheMutex.Unlock()
+	delete(c.contextCache, organizationId)
+	delete(c.ambiguousShortNames, organizationId)
+	delete(c.listLoadedOrgs, organizationId)
+}
 
 func (c *ContextCache) SetOrganizationContext(organizationId string, ctx *Context) *Context {
 	c.cacheMutex.Lock()

--- a/pkg/utils/cache_test.go
+++ b/pkg/utils/cache_test.go
@@ -87,7 +87,6 @@ func TestContextCache_SetOrganizationContext_shortNameCollision(t *testing.T) {
 	}
 }
 
-
 func TestContextCache_listLoadedTracking(t *testing.T) {
 	orgID := "org-uuid"
 	cache := CreateCache()

--- a/pkg/utils/cache_test.go
+++ b/pkg/utils/cache_test.go
@@ -86,3 +86,16 @@ func TestContextCache_SetOrganizationContext_shortNameCollision(t *testing.T) {
 		t.Fatalf("short key should stay dropped after later collision, got %q", got.Name)
 	}
 }
+
+
+func TestContextCache_listLoadedTracking(t *testing.T) {
+	orgID := "org-uuid"
+	cache := CreateCache()
+	if cache.ContextCache.IsOrganizationContextListLoaded(orgID) {
+		t.Fatal("expected list not loaded initially")
+	}
+	cache.ContextCache.MarkOrganizationContextListLoaded(orgID)
+	if !cache.ContextCache.IsOrganizationContextListLoaded(orgID) {
+		t.Fatal("expected list loaded after mark")
+	}
+}

--- a/pkg/utils/context.go
+++ b/pkg/utils/context.go
@@ -86,7 +86,6 @@ func GetAllContext(lsContext *LsContext, orgID string, cache *Cache) error {
 	return nil
 }
 
-
 // GetAllContextWithEnvVars loads contexts including environment variable names when the token
 // has permission. Used for completion; callers should prefer GetAllContext for validation.
 func GetAllContextWithEnvVars(lsContext *LsContext, orgID string, cache *Cache) error {

--- a/pkg/utils/context.go
+++ b/pkg/utils/context.go
@@ -62,7 +62,7 @@ func GetAllContext(lsContext *LsContext, orgID string, cache *Cache) error {
 	pageToken := ""
 
 	for {
-		res, err := getContext(lsContext, orgID, pageToken)
+		res, err := getContext(lsContext, orgID, pageToken, false)
 		if err != nil {
 			return err
 		}
@@ -86,8 +86,49 @@ func GetAllContext(lsContext *LsContext, orgID string, cache *Cache) error {
 	return nil
 }
 
-func getContext(lsContext *LsContext, orgID string, nextPageToken string) (*GetAllContextRes, error) {
-	url := fmt.Sprintf("%s/api/v2/context?owner-id=%s&include-env-vars=true&page-token=%s", lsContext.Api.HostUrl, orgID, nextPageToken)
+
+// GetAllContextWithEnvVars loads contexts including environment variable names when the token
+// has permission. Used for completion; callers should prefer GetAllContext for validation.
+func GetAllContextWithEnvVars(lsContext *LsContext, orgID string, cache *Cache) error {
+	pageToken := ""
+
+	for {
+		res, err := getContext(lsContext, orgID, pageToken, true)
+		if err != nil {
+			return err
+		}
+
+		for _, c := range res.Items {
+			existing := cache.ContextCache.GetOrganizationContext(orgID, c.Name)
+			if existing != nil {
+				existing.envVariables = envVarNames(c.EnvironmentVariables)
+				continue
+			}
+			cache.ContextCache.SetOrganizationContext(orgID, &Context{
+				Id:           c.ID,
+				Name:         c.Name,
+				CreatedAt:    c.CreatedAt.String(),
+				envVariables: envVarNames(c.EnvironmentVariables),
+			})
+		}
+
+		if res.NextPageToken == nil {
+			break
+		}
+
+		pageToken = *res.NextPageToken
+	}
+
+	return nil
+}
+
+func getContext(lsContext *LsContext, orgID string, nextPageToken string, includeEnvVars bool) (*GetAllContextRes, error) {
+	url := fmt.Sprintf("%s/api/v2/context?owner-id=%s&page-token=%s", lsContext.Api.HostUrl, orgID, nextPageToken)
+	if includeEnvVars {
+		// Requires permission to read context environment variables; many users can list
+		// contexts but receive HTTP 403 when env vars are included (private contexts).
+		url = fmt.Sprintf("%s/api/v2/context?owner-id=%s&include-env-vars=true&page-token=%s", lsContext.Api.HostUrl, orgID, nextPageToken)
+	}
 	req, err := http.NewRequest(http.MethodGet, url, nil)
 	if err != nil {
 		return nil, err

--- a/pkg/utils/context_test.go
+++ b/pkg/utils/context_test.go
@@ -97,7 +97,6 @@ func Test_getContext(t *testing.T) {
 	}
 }
 
-
 func Test_getContext_withoutEnvVarsQueryParam(t *testing.T) {
 	orgID := "11111111-2222-3333-4444-555555555555"
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/pkg/utils/context_test.go
+++ b/pkg/utils/context_test.go
@@ -71,7 +71,7 @@ func Test_getContext(t *testing.T) {
 				},
 			}
 
-			got, err := getContext(lsContext, orgID, "")
+			got, err := getContext(lsContext, orgID, "", false)
 			if tt.wantErr != "" {
 				if err == nil {
 					t.Fatalf("getContext() error = nil, want error containing %q", tt.wantErr)
@@ -94,5 +94,74 @@ func Test_getContext(t *testing.T) {
 				t.Fatalf("Items[0].CreatedAt = %v, want %v", got.Items[0].CreatedAt, createdAt)
 			}
 		})
+	}
+}
+
+
+func Test_getContext_withoutEnvVarsQueryParam(t *testing.T) {
+	orgID := "11111111-2222-3333-4444-555555555555"
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Has("include-env-vars") {
+			t.Fatalf("unexpected include-env-vars query param: %s", r.URL.RawQuery)
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"items":[]}`))
+	}))
+	defer server.Close()
+
+	lsContext := &LsContext{Api: ApiContext{Token: "test-token", HostUrl: server.URL}}
+	if _, err := getContext(lsContext, orgID, "", false); err != nil {
+		t.Fatalf("getContext() error = %v", err)
+	}
+}
+
+func Test_getContext_withEnvVarsQueryParam(t *testing.T) {
+	orgID := "11111111-2222-3333-4444-555555555555"
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.URL.Query().Get("include-env-vars"); got != "true" {
+			t.Fatalf("include-env-vars = %q, want true", got)
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"items":[]}`))
+	}))
+	defer server.Close()
+
+	lsContext := &LsContext{Api: ApiContext{Token: "test-token", HostUrl: server.URL}}
+	if _, err := getContext(lsContext, orgID, "", true); err != nil {
+		t.Fatalf("getContext() error = %v", err)
+	}
+}
+
+func Test_GetAllContextWithEnvVars_mergesEnvVarNames(t *testing.T) {
+	orgID := "11111111-2222-3333-4444-555555555555"
+	requests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		w.WriteHeader(http.StatusOK)
+		if r.URL.Query().Has("include-env-vars") {
+			_, _ = w.Write([]byte(`{"items":[{"name":"my-org/deploy","id":"ctx-id","created_at":"2024-01-02T03:04:05Z","environment_variables":[{"variable":"SECRET","truncated_value":"x","created_at":"2024-01-02T03:04:05Z","updated_at":"2024-01-02T03:04:05Z"}]}]}`))
+			return
+		}
+		_, _ = w.Write([]byte(`{"items":[{"name":"my-org/deploy","id":"ctx-id","created_at":"2024-01-02T03:04:05Z"}]}`))
+	}))
+	defer server.Close()
+
+	cache := CreateCache()
+	lsContext := &LsContext{Api: ApiContext{Token: "test-token", HostUrl: server.URL}}
+	if err := GetAllContext(lsContext, orgID, cache); err != nil {
+		t.Fatalf("GetAllContext() error = %v", err)
+	}
+	if err := GetAllContextWithEnvVars(lsContext, orgID, cache); err != nil {
+		t.Fatalf("GetAllContextWithEnvVars() error = %v", err)
+	}
+	ctx := cache.ContextCache.GetOrganizationContext(orgID, "my-org/deploy")
+	if ctx == nil {
+		t.Fatal("expected context in cache")
+	}
+	if len(ctx.envVariables) != 1 || ctx.envVariables[0] != "SECRET" {
+		t.Fatalf("envVariables = %#v, want [SECRET]", ctx.envVariables)
+	}
+	if requests != 2 {
+		t.Fatalf("requests = %d, want 2", requests)
 	}
 }


### PR DESCRIPTION
## Summary

Follow-up to #432 / 0.35.1–0.35.2 for ZD **167313**.

The language server listed contexts with `include-env-vars=true`. That requires permission to read environment variables inside each context. Users whose token is valid for pipelines (same token the VS Code extension sends via `setToken`) can still receive **HTTP 403** on the list call when private contexts are involved.

#432 correctly surfaced the failure in logs (`error getting contexts: ... HTTP 403`) instead of treating the error body as an empty list, but the underlying request still failed — so private contexts continued to show **"Context X does not exist"**.

## Changes

- **`GetAllContext`**: list contexts **without** `include-env-vars` (matches public API docs) for validation
- **`GetAllContextWithEnvVars`**: best-effort second pass with `include-env-vars=true` to enrich completion only; failure is logged, not fatal
- **Validation**: only emit context-existence diagnostics after a successful context list load
- **`ClearHostData`**: clear context cache on token/host change

## Testing

```
go test ./pkg/utils/... ./pkg/parser/validate/...
```

Manual repro (customer / support):

```bash
# Often 403 for users who can list contexts in the UI
curl -H "Circle-Token: $CIRCLE_TOKEN"   "https://circleci.com/api/v2/context?owner-id=<org-id>&include-env-vars=true"

# Should succeed and return context names
curl -H "Circle-Token: $CIRCLE_TOKEN"   "https://circleci.com/api/v2/context?owner-id=<org-id>"
```

## Local VS Code / Cursor validation

From this repo with a personal API token:

```bash
export CIRCLE_TOKEN=<token>
task prepare:vscode   # or npm install in editors/vscode
# Run the embedded dev extension (Run Extension) and open a config using private contexts
```