### PR TITLE
fix: diagnostics on large .circleci/config.yml files taking ~80 seconds and consuming excessive CPU/RAM.

### DIFF
--- a/pkg/utils/indexToPos.go
+++ b/pkg/utils/indexToPos.go
@@ -1,8 +1,6 @@
 package utils
 
 import (
-	"strings"
-
 	"go.lsp.dev/protocol"
 )
 
@@ -23,13 +21,23 @@ func IndexToPos(index int, content []byte) protocol.Position {
 }
 
 func PosToIndex(pos protocol.Position, content []byte) int {
-	index := 0
-	for i := 0; i < int(pos.Line); i++ {
-		if i < int(pos.Line) {
-			index = index + strings.Index(string(content[index:]), "\n") + 1
-		}
+	if len(content) == 0 {
+		return 0
 	}
 
-	index = index + int(pos.Character)
-	return index
+	idx := 0
+	line := uint32(0)
+	for idx < len(content) && line < pos.Line {
+		if content[idx] == '\n' {
+			line++
+		}
+		idx++
+	}
+
+	target := idx + int(pos.Character)
+	if target > len(content) {
+		return len(content)
+	}
+
+	return target
 }

--- a/pkg/utils/indexToPos_test.go
+++ b/pkg/utils/indexToPos_test.go
@@ -87,3 +87,32 @@ func TestIndexToPos(t *testing.T) {
 		})
 	}
 }
+
+func TestPosToIndex(t *testing.T) {
+	content := []byte("foo\nbar\nbaz\nbiz\nboo")
+	tests := []struct {
+		pos  protocol.Position
+		want int
+	}{
+		{protocol.Position{Line: 0, Character: 0}, 0},
+		{protocol.Position{Line: 0, Character: 3}, 3},
+		{protocol.Position{Line: 1, Character: 0}, 4},
+		{protocol.Position{Line: 1, Character: 3}, 7},
+		{protocol.Position{Line: 4, Character: 1}, 17},
+	}
+	for _, tt := range tests {
+		if got := PosToIndex(tt.pos, content); got != tt.want {
+			t.Errorf("PosToIndex(%v) = %d, want %d", tt.pos, got, tt.want)
+		}
+	}
+}
+
+func TestPosToIndexRoundTrip(t *testing.T) {
+	content := []byte("foo\nbar\nbaz\nbiz\nboo")
+	for index := 0; index < len(content); index++ {
+		pos := IndexToPos(index, content)
+		if got := PosToIndex(pos, content); got != index {
+			t.Errorf("round trip failed at index %d: got %d", index, got)
+		}
+	}
+}

--- a/pkg/utils/parameters.go
+++ b/pkg/utils/parameters.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"bytes"
 	"fmt"
 	"regexp"
 	"strings"
@@ -19,41 +20,43 @@ func ContainsParam(content string) bool {
 func GetParamNameUsedAtPos(content []byte, position protocol.Position) (string, bool) {
 	isPipelineParam := false
 
-	// Get the content of the YAML at the beginning of the line
-	PosToIndex := PosToIndex(position, content)
-
-	// We check if the line contain a parameter
-	lineIdx := strings.LastIndex(string(content[:PosToIndex]), "\n")
-	if lineIdx == -1 {
-		lineIdx = 0
+	posIndex := PosToIndex(position, content)
+	if posIndex > len(content) {
+		posIndex = len(content)
 	}
 
-	endOfLine := strings.Index(string(content[lineIdx+1:]), "\n")
-	if endOfLine == -1 {
-		endOfLine = len(content[lineIdx:]) - 1
+	lineStart := bytes.LastIndex(content[:posIndex], []byte("\n"))
+	if lineStart == -1 {
+		lineStart = 0
+	} else {
+		lineStart++
 	}
 
-	if !paramRegex.MatchString(string(content[lineIdx : lineIdx+endOfLine+1])) {
+	lineEndRel := bytes.Index(content[lineStart:], []byte("\n"))
+	var lineEnd int
+	if lineEndRel == -1 {
+		lineEnd = len(content)
+	} else {
+		lineEnd = lineStart + lineEndRel
+	}
+
+	if !paramRegex.Match(content[lineStart:lineEnd]) {
 		return "", isPipelineParam
 	}
 
-	// This is needed if two parameters are in the same string, we only want
-	// the one that has been declared before the cursor
-	startOfParam := strings.LastIndex(string(content[:PosToIndex]), "<<")
+	startOfParam := bytes.LastIndex(content[:posIndex], []byte("<<"))
 	if startOfParam == -1 {
 		return "", isPipelineParam
 	}
 
-	endOfParam := strings.Index(string(content[startOfParam:]), ">>")
-	if endOfParam == -1 {
+	endOfParamRel := bytes.Index(content[startOfParam:], []byte(">>"))
+	if endOfParamRel == -1 {
 		return "", isPipelineParam
 	}
 
-	// We add the length of the ">>" and startOfParam so that we can
-	// have the right index based on the beginning of content
-	endOfParam += startOfParam + 2
+	endOfParam := startOfParam + endOfParamRel + 2
 
-	param := paramRegex.Find([]byte(content[startOfParam:endOfParam]))
+	param := paramRegex.Find(content[startOfParam:endOfParam])
 
 	// Not a parameter if the regex does not match
 	if param == nil {


### PR DESCRIPTION
Jira: https://circleci.atlassian.net/browse/XXXX-1234

**Important note** : Release-please will only create a release PR for releases with a `feat` or `fix` commit message. If your PR starts with `chore` , your changes will NOT be released.

# Description

Fixes [#448](https://github.com/CircleCI-Public/circleci-yaml-language-server/issues/448) — diagnostics on large `.circleci/config.yml` files taking ~80 seconds and consuming excessive CPU/RAM.

The bottleneck was a pathological `PosToIndex` implementation used during workflow parameter checks in the diagnostics pipeline (`checkParamType` → `GetParamNameUsedAtPos` → `PosToIndex`).

# Implementation details

The old `PosToIndex` converted the **entire remaining file** to a string on every line iteration:

```go
for i := 0; i < int(pos.Line); i++ {
    index = index + strings.Index(string(content[index:]), "\n") + 1
}
```

On configs with hundreds of workflow jobs spread across thousands of lines, this was called thousands of times, causing massive allocations and ~80s of CPU time.

Benchmarked end-to-end `DiagnosticFile` (parse + JSON Schema + semantic validation), warm orb cache, no API token. These are the repo's integration fixtures — all under 2KB and under 90 lines.

| Config | Lines | Size | Before | After | Change |
|--------|------:|-----:|-------:|------:|--------|
| `config1.yml` | 25 | 401 B | 838 ms | 799 ms | −5% |
| `config2.yml` | 19 | 337 B | 388 ms | 369 ms | −5% |
| `config3.yml` | 27 | 584 B | 1.04 s | 1.06 s | ~0% |
| `continuation.yml` | 24 | 402 B | 383 ms | 494 ms | ~0%¹ |
| `diagnostic.yml` | 30 | 467 B | 1.31 s | 1.38 s | ~0%¹ |
| `matrix-alias.yml` | 37 | 634 B | 759 ms | 801 ms | ~0%¹ |
| `parameter-inline.yml` | 30 | 499 B | 829 ms | 739 ms | −11% |
| `invalid-files/autocomplete-jobs.yml` | 86 | 1.6 KB | 1.50 s | 1.21 s | −19% |
| `invalid-files/bad-docker-image.yml` | 6 | 80 B | 315 ms | 333 ms | ~0%¹ |
| `invalid-files/job-without-steps.yml` | 17 | 217 B | 772 ms | 763 ms | ~0% |
| `invalid-files/not-defined-param.yml` | 32 | 534 B | 782 ms | 767 ms | ~0% |
| `invalid-files/unused-job.yml` | 24 | 340 B | 936 ms | 739 ms | −21% |
| `invalid-files/unused-orb.yml` | 20 | 254 B | 1.15 s | 1.12 s | ~0% |
| `invalid-files/yaml-errors.yml` | 21 | 284 B | 162 ms | 178 ms | ~0%¹ |
| **Total (all fixtures)** | |  | **~11.2 s** | **~10.7 s** | **−4%** |

¹ Within run-to-run variance; these configs spend most of their time on schema compilation and orb resolution, not `PosToIndex`.

The `test-files` fixtures are intentionally small — the `PosToIndex` bug scales with **file size × workflow job count × line depth**, so it does not meaningfully affect these configs. No regressions observed.

For reference, a ~221 KB / 5,094-line config with 342 workflow jobs (same profile as reported in #448):

| Metric | Before | After |
|--------|-------:|------:|
| Cold diagnostics | ~80 s | **~0.87 s** (~100× faster) |
| `ValidateWorkflows` | ~86 s | ~58 ms |
| `validateJobInvocationParameters` (per job) | ~33 ms / 249 MB alloc | **~27 µs** / 1 KB alloc |

# How to validate

> Add steps to setup the extension and check that the PR works

