### PR TITLE
feat(schema): add support for URL orbs

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -2419,7 +2419,7 @@
             ],
             "markdownDescription": "https://circleci.com/docs/configuration-reference#orbs-requires-version-21\n\nOrbs are reusable packages of CircleCI configuration that you may share across projects, enabling you to create encapsulated, parameterized commands, jobs, and executors that can be used across multiple projects.",
             "additionalProperties": {
-                "markdownDescription": "An orb reference can be specified in multiple ways:\n\n**String with semantic version:**\n- `namespace/orb-name@1.2.3` - specific version\n- `namespace/orb-name@1.2` - latest patch version of 1.2.x\n- `namespace/orb-name@1` - latest minor and patch of 1.x.x\n- `namespace/orb-name@volatile` - most recent release\n- `namespace/orb-name@dev:branch-name` - development version\n\n**String with parameter substitution:**\n- `namespace/orb-name@<<parameters.version>>`\n- `namespace/orb-name@<<pipeline.parameters.version>>`\n\n**Inline orb object:** Define jobs, commands, and executors directly in this configuration.\n\nSee [Orb Concepts](https://circleci.com/docs/orbs/author/orb-concepts/#semantic-versioning) and [Creating Inline Orbs](https://circleci.com/docs/reference/reusing-config/#writing-inline-orbs) for more details.",
+                "markdownDescription": "An orb reference can be specified in multiple ways:\n\n**String with semantic version:**\n- `namespace/orb-name@1.2.3` - specific version\n- `namespace/orb-name@1.2` - latest patch version of 1.2.x\n- `namespace/orb-name@1` - latest minor and patch of 1.x.x\n- `namespace/orb-name@volatile` - most recent release\n- `namespace/orb-name@dev:branch-name` - development version\n\n**String with parameter substitution:**\n- `namespace/orb-name@<<parameters.version>>`\n- `namespace/orb-name@<<pipeline.parameters.version>>`\n\n**Inline orb object:** Define jobs, commands, and executors directly in this configuration.\n\n**URL orb:** A HTTPS URL to a YAML file containing the orb definition, for example in a GitHub repository.\n\nSee [Orb Concepts](https://circleci.com/docs/orbs/author/orb-concepts/#semantic-versioning) and [Creating Inline Orbs](https://circleci.com/docs/reference/reusing-config/#writing-inline-orbs) for more details.",
                 "oneOf": [
                     {
                         "type": "string",
@@ -2428,6 +2428,11 @@
                     {
                         "type": "string",
                         "pattern": "^[a-z][a-z0-9_-]+/[a-z][a-z0-9_-]+@ *<<.+>> *$"
+                    },
+                    {
+                        "type": "string",
+                        "pattern": "^https://.+$",
+                        "format": "uri"
                     },
                     {
                         "type": "object",


### PR DESCRIPTION
**Important note** : Release-please will only create a release PR for releases with a `feat` or `fix` commit message. If your PR starts with `chore` , your changes will NOT be released.

# Description

Adds support for URL orbs in the JSON schema, e.g.:

```yaml
version: 2.1

orbs:
  platform: https://raw.githubusercontent.com/my-org/orbs/refs/heads/main/platform-team.yaml
```

# Implementation details

URLs are [not easy to validate with regular expressions](https://mathiasbynens.be/demo/url-regex), so I've just validated that it starts with `https://` (since only HTTPS URLs are supported), and also added a `uri` format hint.

# How to validate

I tried to add test cases for this in the existing tests, but I couldn't find one that only used the JSON schema, they mostly seem to use the full language server parsing, which doesn't support URL orbs as far as I can tell, and I don't really have the time to fully implement that at this time.

I did test that the schema using [jsonschema.dev](https://jsonschema.dev/), just pasting the new schema in there. It succeeded with the following:

```json
{
  "version": "2.1",
  "orbs": {
    "platform": "https://example.com",
    "foo": "foo/bar@1.2.3"
  }
}
```

And it failed with these:

Invalid URL:
```json
{
  "version": "2.1",
  "orbs": {
    "platform": "https://example.com ",
    "foo": "foo/bar@1.2.3"
  }
}
```

`http://` URL:
```json
{
  "version": "2.1",
  "orbs": {
    "platform": "http://example.com",
    "foo": "foo/bar@1.2.3"
  }
}
```