### PR TITLE
feat(schema): add support for teardown steps on run steps

### DIFF
--- a/pkg/ast/step.go
+++ b/pkg/ast/step.go
@@ -66,6 +66,7 @@ type Run struct {
 	IsDeployStep     bool
 	MaxAutoReruns    string
 	AutoRerunDelay   string
+	Teardown         []Step
 }
 
 func (step Run) GetRange() protocol.Range {

--- a/pkg/parser/jsonschema_test.go
+++ b/pkg/parser/jsonschema_test.go
@@ -331,3 +331,132 @@ jobs:
 		})
 	}
 }
+
+func Test_TeardownSteps(t *testing.T) {
+	testCases := []struct {
+		name          string
+		steps         string
+		expectInvalid bool
+		expectError   string
+	}{
+		{
+			name: "a list of teardown steps, with the keys that are not inherited from the parent",
+			steps: `
+      - run:
+          command: make build
+          teardown:
+            - run: ./save-cache.sh
+            - run:
+                command: ./report.sh
+                when: on_fail
+                shell: /bin/sh
+                working_directory: /tmp
+                no_output_timeout: 5m
+                background: false`,
+		},
+		{
+			name: "a single teardown step, not in a list",
+			steps: `
+      - run:
+          command: make build
+          teardown:
+            run:
+              command: ./save-cache.sh
+              when: always`,
+		},
+		{
+			name: "a backgrounded teardown step is rejected",
+			steps: `
+      - run:
+          command: make build
+          teardown:
+            - run:
+                command: ./tail-logs.sh
+                background: true`,
+			expectInvalid: true,
+			expectError:   "background",
+		},
+		{
+			// `not` gives no field name, so only the rejection itself can be asserted.
+			name: "a teardown step cannot declare teardown steps of its own",
+			steps: `
+      - run:
+          command: make build
+          teardown:
+            - run:
+                command: ./save-cache.sh
+                teardown:
+                  - run: ./nested.sh`,
+			expectInvalid: true,
+		},
+		{
+			name: "a teardown step must be a run step",
+			steps: `
+      - run:
+          command: make build
+          teardown:
+            - save_cache:
+                key: k
+                paths:
+                  - /tmp`,
+			expectInvalid: true,
+			expectError:   "run",
+		},
+		{
+			name: "an invalid when is rejected",
+			steps: `
+      - run:
+          command: make build
+          teardown:
+            - run:
+                command: ./save-cache.sh
+                when: sometimes`,
+			expectInvalid: true,
+			expectError:   "when",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			content := `version: 2.1
+jobs:
+  build:
+    docker:
+      - image: cimg/base:stable
+    steps:` + tc.steps + `
+workflows:
+  workflow:
+    jobs:
+      - build
+`
+			context := testHelpers.GetDefaultLsContext()
+			yamlDocument, _ := ParseFromContent([]byte(content), context, uri.File(""), protocol.Position{})
+
+			validator := JSONSchemaValidator{Doc: yamlDocument}
+			if err := validator.LoadJsonSchemaFromBytes(schema.EmbeddedSchemaJSON); err != nil {
+				t.Fatalf("could not load schema: %v", err)
+			}
+
+			diagnostics := validator.ValidateWithJSONSchema(yamlDocument.RootNode, yamlDocument.Content)
+
+			if !tc.expectInvalid {
+				assert.Empty(t, diagnostics, "expected the config to validate")
+				return
+			}
+
+			assert.NotEmpty(t, diagnostics, "expected a validation error")
+			if tc.expectError == "" {
+				return
+			}
+
+			found := false
+			for _, d := range diagnostics {
+				if strings.Contains(strings.ToLower(d.Message), tc.expectError) {
+					found = true
+					break
+				}
+			}
+			assert.True(t, found, "expected an error mentioning %q, got %v", tc.expectError, diagnostics)
+		})
+	}
+}

--- a/pkg/parser/steps.go
+++ b/pkg/parser/steps.go
@@ -280,10 +280,25 @@ func (doc *YamlDocument) parseRunStep(runNode *sitter.Node) ast.Run {
 				res.MaxAutoReruns = doc.GetNodeText(valueNode)
 			case "auto_rerun_delay":
 				res.AutoRerunDelay = doc.GetNodeText(valueNode)
+			case "teardown":
+				res.Teardown = doc.parseTeardownSteps(valueNode)
 			}
 		})
 		return res
 	}
+}
+
+// Teardown steps are a list of run steps, or a single one.
+func (doc *YamlDocument) parseTeardownSteps(blockNode *sitter.Node) []ast.Step {
+	if GetChildSequence(blockNode) != nil {
+		return doc.parseSteps(blockNode)
+	}
+
+	if blockMapping := GetChildMapping(blockNode); blockMapping != nil {
+		return doc.parseStep(blockMapping)
+	}
+
+	return nil
 }
 
 func (doc *YamlDocument) parseCheckoutStep(checkoutNode *sitter.Node) ast.Checkout {

--- a/pkg/parser/steps_test.go
+++ b/pkg/parser/steps_test.go
@@ -187,3 +187,74 @@ func TestYamlDocument_parseSteps(t *testing.T) {
 		})
 	}
 }
+
+func TestYamlDocument_parseTeardownSteps(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		want    []string
+	}{
+		{
+			name: "a list of teardown steps",
+			content: `
+steps:
+    - run:
+        command: make build
+        teardown:
+            - run: ./save-cache.sh
+            - run:
+                command: ./report.sh
+                when: on_fail
+`,
+			want: []string{"./save-cache.sh", "./report.sh"},
+		},
+		{
+			name: "a single teardown step, not in a list",
+			content: `
+steps:
+    - run:
+        command: make build
+        teardown:
+            run:
+                command: ./save-cache.sh
+`,
+			want: []string{"./save-cache.sh"},
+		},
+		{
+			name: "no teardown steps",
+			content: `
+steps:
+    - run:
+        command: make build
+`,
+			want: []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rootNode := GetRootNode([]byte(tt.content))
+			stepsNode := getFirstChildOfType(rootNode, "block_sequence").Parent()
+			doc := &YamlDocument{Content: []byte(tt.content)}
+
+			steps := doc.parseSteps(stepsNode)
+			run, ok := steps[0].(ast.Run)
+			if !ok {
+				t.Fatalf("expected a run step, got %v", reflect.TypeOf(steps[0]))
+			}
+
+			got := []string{}
+			for _, teardown := range run.Teardown {
+				teardownRun, ok := teardown.(ast.Run)
+				if !ok {
+					t.Fatalf("expected a run step, got %v", reflect.TypeOf(teardown))
+				}
+				got = append(got, teardownRun.Command)
+			}
+
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("parsed teardown commands %v, expected %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/parser/validate/steps.go
+++ b/pkg/parser/validate/steps.go
@@ -27,6 +27,7 @@ func (val Validate) validateSteps(steps []ast.Step, name string, jobOrCommandPar
 		switch step := step.(type) {
 		case ast.Run:
 			val.validateRunCommand(step, jobOrCommandParameters)
+			val.validateSteps(step.Teardown, name, jobOrCommandParameters)
 		case ast.NamedStep:
 			val.validateNamedStep(step, jobOrCommandParameters)
 		case ast.Steps:

--- a/pkg/parser/validate/steps_test.go
+++ b/pkg/parser/validate/steps_test.go
@@ -4,6 +4,7 @@ import (
 	_ "embed"
 	"testing"
 
+	"github.com/CircleCI-Public/circleci-yaml-language-server/pkg/utils"
 	"go.lsp.dev/protocol"
 )
 
@@ -134,5 +135,105 @@ func TestYamlDocument_parseCheckout(t *testing.T) {
 			},
 		},
 	}
+	CheckYamlErrors(t, testCases)
+}
+
+func TestTeardownStepsValidation(t *testing.T) {
+	testCases := []ValidateTestCase{
+		{
+			Name: "A valid teardown step does not result in an error",
+			YamlContent: `version: 2.1
+
+jobs:
+  build:
+    docker:
+      - image: cimg/base:stable
+    steps:
+      - run:
+          command: make build
+          teardown:
+            - run:
+                command: ./save-cache.sh
+                when: always
+
+workflows:
+  workflow:
+    jobs:
+      - build
+`,
+			OnlyErrors:  true,
+			Diagnostics: []protocol.Diagnostic{},
+		},
+		{
+			Name: "A teardown step's own fields are validated",
+			YamlContent: `version: 2.1
+
+jobs:
+  build:
+    docker:
+      - image: cimg/base:stable
+    steps:
+      - run:
+          command: make build
+          teardown:
+            - run:
+                command: ./save-cache.sh
+                when: sometimes
+
+workflows:
+  workflow:
+    jobs:
+      - build
+`,
+			OnlyErrors: true,
+			Diagnostics: []protocol.Diagnostic{
+				utils.CreateErrorDiagnosticFromRange(
+					protocol.Range{
+						Start: protocol.Position{Line: 12, Character: 22},
+						End:   protocol.Position{Line: 12, Character: 31},
+					},
+					"Invalid when condition: expected `on_success`, `always`, `on_fail`; got `sometimes`",
+				),
+			},
+		},
+		{
+			Name: "A teardown step declared inside a command is validated",
+			YamlContent: `version: 2.1
+
+commands:
+  greet:
+    steps:
+      - run:
+          command: echo hello
+          teardown:
+            - run:
+                command: ./save-cache.sh
+                when: nope
+
+jobs:
+  build:
+    docker:
+      - image: cimg/base:stable
+    steps:
+      - greet
+
+workflows:
+  workflow:
+    jobs:
+      - build
+`,
+			OnlyErrors: true,
+			Diagnostics: []protocol.Diagnostic{
+				utils.CreateErrorDiagnosticFromRange(
+					protocol.Range{
+						Start: protocol.Position{Line: 10, Character: 22},
+						End:   protocol.Position{Line: 10, Character: 26},
+					},
+					"Invalid when condition: expected `on_success`, `always`, `on_fail`; got `nope`",
+				),
+			},
+		},
+	}
+
 	CheckYamlErrors(t, testCases)
 }

--- a/schema.json
+++ b/schema.json
@@ -1137,6 +1137,59 @@
                 }
             ]
         },
+        "teardownStep": {
+            "type": "object",
+            "markdownDescription": "A step to be run at the end of the job.",
+            "properties": {
+                "run": {
+                    "oneOf": [
+                        {
+                            "type": "string",
+                            "markdownDescription": "`{run: \"...\"}` is shorthand for `{run: {command: \"...\"}}`"
+                        },
+                        {
+                            "type": "object",
+                            "properties": {
+                                "command": {
+                                    "type": "string",
+                                    "markdownDescription": "Command to run via the shell"
+                                },
+                                "name": {
+                                    "type": "string",
+                                    "markdownDescription": "Title of the step to be shown in the CircleCI UI (default: full `command`)"
+                                },
+                                "when": {
+                                    "enum": [
+                                        "always",
+                                        "on_success",
+                                        "on_fail"
+                                    ],
+                                    "markdownDescription": "Specify when to enable or disable the step. Takes the following values: `always`, `on_success`, `on_fail` (default: `always` for teardown steps)"
+                                },
+                                "background": {
+                                    "enum": [
+                                        false
+                                    ],
+                                    "markdownDescription": "A teardown step cannot be backgrounded, it would be cancelled as soon as it started"
+                                }
+                            },
+                            "required": [
+                                "command"
+                            ],
+                            "not": {
+                                "required": [
+                                    "teardown"
+                                ]
+                            }
+                        }
+                    ]
+                }
+            },
+            "required": [
+                "run"
+            ],
+            "additionalProperties": false
+        },
         "step": {
             "oneOf": [
                 {
@@ -1213,6 +1266,20 @@
                                             "type": "string",
                                             "pattern": "^(10|[1-9])m|([1-9][0-9]*)s$",
                                             "markdownDescription": "Delay before automatic rerun of this step"
+                                        },
+                                        "teardown": {
+                                            "markdownDescription": "Steps to be run at the end of the job, in reverse order, whether or not it succeeded.",
+                                            "oneOf": [
+                                                {
+                                                    "$ref": "#/definitions/teardownStep"
+                                                },
+                                                {
+                                                    "type": "array",
+                                                    "items": {
+                                                        "$ref": "#/definitions/teardownStep"
+                                                    }
+                                                }
+                                            ]
                                         }
                                     },
                                     "required": [


### PR DESCRIPTION
PIE-135

# Description

A `run` step may declare `teardown` steps, which the task agent runs at the end of the job in reverse order. Today the key is silently dropped, so it gets no completion or hover and nothing inside the block is checked.

# Implementation details

- `schema.json` — a `teardownStep` definition. Teardown steps are `run` steps only, cannot nest another `teardown`, and cannot be backgrounded. `when` defaults to `always`.
- `pkg/parser/steps.go` — `parseTeardownSteps` reads the block into the AST instead of dropping it, accepting a list or a single step.
- `pkg/parser/validate/steps.go` — recurse into `step.Teardown`, so parameter references and step fields inside the block are validated.

# How to validate

In a `.circleci/config.yml`:

```yaml
jobs:
  build:
    machine: true
    steps:
      - run:
          command: make build
          teardown:
            - run: ./save-cache.sh
```

- `teardown` completes on a `run` step, and hovering it shows a description
- `background: true` on a teardown step is flagged
- a `teardown` inside a teardown step is flagged
- `<< parameters.nope >>` inside a teardown step is reported as an unknown parameter

# Note on sequencing

The config support this describes has not shipped yet. `schema.json` is served from `main` unpinned, so merging this offers `teardown` in the editor to everyone immediately. Best held until the compiler and task agent support is released.
