### PR TITLE
fix(schema): allow when on all built-in steps via shared definition

### DIFF
--- a/pkg/services/diagnostics_test.go
+++ b/pkg/services/diagnostics_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/CircleCI-Public/circleci-yaml-language-server/pkg/testHelpers"
@@ -36,6 +37,11 @@ func TestFindErrors(t *testing.T) {
 		{
 			name: "No errors",
 			args: args{filePath: "./testdata/requiresNoErrors.yml"},
+			want: make([]protocol.Diagnostic, 0),
+		},
+		{
+			name: "No errors",
+			args: args{filePath: "./testdata/stepWhen.yml"},
 			want: make([]protocol.Diagnostic, 0),
 		},
 	}
@@ -78,6 +84,11 @@ func TestFindErrorsWithEmbeddedSchema(t *testing.T) {
 		{
 			name:     "No errors with embedded schema",
 			filePath: "./testdata/noErrors.yml",
+			want:     make([]protocol.Diagnostic, 0),
+		},
+		{
+			name:     "when attribute on every built-in step with embedded schema",
+			filePath: "./testdata/stepWhen.yml",
 			want:     make([]protocol.Diagnostic, 0),
 		},
 	}
@@ -378,6 +389,57 @@ func TestDeduplicateDiagnosticsByRange(t *testing.T) {
 			if !reflect.DeepEqual(result, tt.expected) {
 				t.Errorf("deduplicateDiagnosticsByRange() = %v, want %v", result, tt.expected)
 			}
+		})
+	}
+}
+
+func TestStepWhenRejectsInvalidValue(t *testing.T) {
+	const filePath = "./testdata/stepWhenInvalid.yml"
+
+	stepNames := []string{
+		"checkout",
+		"setup_remote_docker",
+		"add_ssh_keys",
+		"restore_cache",
+		"run",
+		"save_cache",
+		"store_artifacts",
+		"store_test_results",
+		"persist_to_workspace",
+		"attach_workspace",
+	}
+
+	content, err := os.ReadFile(filePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cache := utils.CreateCache()
+	cache.FileCache.SetFile(utils.CachedFile{
+		TextDocument: protocol.TextDocumentItem{
+			URI:  uri.File(filePath),
+			Text: string(content),
+		},
+		Project:      utils.Project{},
+		EnvVariables: make([]string, 0),
+	})
+	context := testHelpers.GetDefaultLsContext()
+	context.Api.Token = ""
+
+	diagnostics, err := DiagnosticFile(uri.File(filePath), cache, context, "")
+	if err != nil {
+		t.Fatalf("DiagnosticFile() returned error: %v", err)
+	}
+
+	for _, stepName := range stepNames {
+		t.Run(stepName, func(t *testing.T) {
+			wanted := "." + stepName + `.when must be one of the following: "always", "on_success", "on_fail"`
+			for _, diagnostic := range diagnostics {
+				if strings.Contains(diagnostic.Message, wanted) {
+					return
+				}
+			}
+			t.Errorf("DiagnosticFile() in file %s = %v, want a diagnostic containing %q", filePath, diagnostics, wanted)
 		})
 	}
 }

--- a/pkg/services/testdata/stepWhen.yml
+++ b/pkg/services/testdata/stepWhen.yml
@@ -1,0 +1,52 @@
+version: 2.1
+
+jobs:
+  everyStepWithWhen:
+    docker:
+      - image: cimg/base:current
+    steps:
+      - checkout:
+          path: ~/src
+          when: always
+      - setup_remote_docker:
+          docker_layer_caching: true
+          when: on_success
+      - add_ssh_keys:
+          fingerprints:
+            - "SO:ME:FIN:G:ER:PR:IN:T"
+          when: always
+      - restore_cache:
+          key: v1-deps-{{ checksum "go.sum" }}
+          when: always
+      - restore_cache:
+          keys:
+            - v1-deps-{{ checksum "go.sum" }}
+            - v1-deps-
+          when: on_success
+      - run:
+          command: echo "hello"
+          when: on_fail
+      - save_cache:
+          key: v1-deps-{{ checksum "go.sum" }}
+          paths:
+            - ~/go/pkg/mod
+          when: always
+      - store_artifacts:
+          path: build/reports
+          when: always
+      - store_test_results:
+          path: test-results
+          when: always
+      - persist_to_workspace:
+          root: workspace
+          paths:
+            - artifact
+          when: on_success
+      - attach_workspace:
+          at: workspace
+          when: on_fail
+
+workflows:
+  test-when:
+    jobs:
+      - everyStepWithWhen

--- a/pkg/services/testdata/stepWhenInvalid.yml
+++ b/pkg/services/testdata/stepWhenInvalid.yml
@@ -1,0 +1,51 @@
+version: 2.1
+
+jobs:
+  everyStepWithBadWhen:
+    docker:
+      - image: cimg/base:current
+    steps:
+      - checkout:
+          path: ~/src
+          when: sometimes
+      - setup_remote_docker:
+          docker_layer_caching: true
+          when: sometimes
+      - add_ssh_keys:
+          fingerprints:
+            - "SO:ME:FIN:G:ER:PR:IN:T"
+          when: sometimes
+      - restore_cache:
+          key: v1-deps-{{ checksum "go.sum" }}
+          when: sometimes
+      - restore_cache:
+          keys:
+            - v1-deps-{{ checksum "go.sum" }}
+          when: sometimes
+      - run:
+          command: echo "hello"
+          when: sometimes
+      - save_cache:
+          key: v1-deps-{{ checksum "go.sum" }}
+          paths:
+            - ~/go/pkg/mod
+          when: sometimes
+      - store_artifacts:
+          path: build/reports
+          when: sometimes
+      - store_test_results:
+          path: test-results
+          when: sometimes
+      - persist_to_workspace:
+          root: workspace
+          paths:
+            - artifact
+          when: sometimes
+      - attach_workspace:
+          at: workspace
+          when: sometimes
+
+workflows:
+  test-when:
+    jobs:
+      - everyStepWithBadWhen

--- a/schema.json
+++ b/schema.json
@@ -2,6 +2,14 @@
     "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "CircleCI Config",
     "definitions": {
+        "stepWhen": {
+            "enum": [
+                "always",
+                "on_success",
+                "on_fail"
+            ],
+            "markdownDescription": "Specify when to enable or disable the step. Takes the following values: `always`, `on_success`, `on_fail` (default: `on_success`)"
+        },
         "jobInvocation": {
             "oneOf": [
                 {
@@ -1196,12 +1204,7 @@
                                             "markdownDescription": "Elapsed time the command can run without output. The string is a decimal with unit suffix, such as \"20m\", \"1.25h\", \"5s\" (default: 10 minutes)"
                                         },
                                         "when": {
-                                            "enum": [
-                                                "always",
-                                                "on_success",
-                                                "on_fail"
-                                            ],
-                                            "markdownDescription": "Specify when to enable or disable the step. Takes the following values: `always`, `on_success`, `on_fail` (default: `on_success`)"
+                                            "$ref": "#/definitions/stepWhen"
                                         },
                                         "max_auto_reruns": {
                                             "type": "integer",
@@ -1263,6 +1266,9 @@
                                             "type": "integer",
                                             "minimum": 1,
                                             "markdownDescription": "The depth of the shallow clone. Only valid when `method` is set to 'shallow'. Must be a positive integer."
+                                        },
+                                        "when": {
+                                            "$ref": "#/definitions/stepWhen"
                                         }
                                     },
                                     "additionalProperties": false
@@ -1309,6 +1315,9 @@
                                                     "type": "string"
                                                 }
                                             ]
+                                        },
+                                        "when": {
+                                            "$ref": "#/definitions/stepWhen"
                                         }
                                     },
                                     "additionalProperties": false
@@ -1339,12 +1348,7 @@
                                     "markdownDescription": "Title of the step to be shown in the CircleCI UI (default: 'Saving Cache')"
                                 },
                                 "when": {
-                                    "enum": [
-                                        "always",
-                                        "on_success",
-                                        "on_fail"
-                                    ],
-                                    "markdownDescription": "Specify when to enable or disable the step. Takes the following values: `always`, `on_success`, `on_fail` (default: `on_success`)"
+                                    "$ref": "#/definitions/stepWhen"
                                 }
                             },
                             "additionalProperties": false
@@ -1365,6 +1369,9 @@
                                         "name": {
                                             "type": "string",
                                             "markdownDescription": "Title of the step to be shown in the CircleCI UI (default: 'Restoring Cache')"
+                                        },
+                                        "when": {
+                                            "$ref": "#/definitions/stepWhen"
                                         }
                                     },
                                     "additionalProperties": false
@@ -1385,6 +1392,9 @@
                                         "name": {
                                             "type": "string",
                                             "markdownDescription": "Title of the step to be shown in the CircleCI UI (default: 'Restoring Cache')"
+                                        },
+                                        "when": {
+                                            "$ref": "#/definitions/stepWhen"
                                         }
                                     },
                                     "additionalProperties": false
@@ -1411,12 +1421,7 @@
                                     "markdownDescription": "Title of the step to be shown in the CircleCI UI"
                                 },
                                 "when": {
-                                    "enum": [
-                                        "always",
-                                        "on_success",
-                                        "on_fail"
-                                    ],
-                                    "markdownDescription": "Specify when to enable or disable the step. Takes the following values: `always`, `on_success`, `on_fail` (default: `on_success`)"
+                                    "$ref": "#/definitions/stepWhen"
                                 }
                             },
                             "additionalProperties": false
@@ -1437,12 +1442,7 @@
                                     "markdownDescription": "Title of the step to be shown in the CircleCI UI"
                                 },
                                 "when": {
-                                    "enum": [
-                                        "always",
-                                        "on_success",
-                                        "on_fail"
-                                    ],
-                                    "markdownDescription": "Specify when to enable or disable the step. Takes the following values: `always`, `on_success`, `on_fail` (default: `on_success`)"
+                                    "$ref": "#/definitions/stepWhen"
                                 }
                             },
                             "additionalProperties": false
@@ -1471,12 +1471,7 @@
                                     "markdownDescription": "Title of the step to be shown in the CircleCI UI"
                                 },
                                 "when": {
-                                    "enum": [
-                                        "always",
-                                        "on_success",
-                                        "on_fail"
-                                    ],
-                                    "markdownDescription": "Specify when to enable or disable the step. Takes the following values: `always`, `on_success`, `on_fail` (default: `on_success`)"
+                                    "$ref": "#/definitions/stepWhen"
                                 }
                             },
                             "additionalProperties": false
@@ -1497,12 +1492,7 @@
                                     "markdownDescription": "Title of the step to be shown in the CircleCI UI"
                                 },
                                 "when": {
-                                    "enum": [
-                                        "always",
-                                        "on_success",
-                                        "on_fail"
-                                    ],
-                                    "markdownDescription": "Specify when to enable or disable the step. Takes the following values: `always`, `on_success`, `on_fail` (default: `on_success`)"
+                                    "$ref": "#/definitions/stepWhen"
                                 }
                             },
                             "additionalProperties": false
@@ -1525,6 +1515,9 @@
                                                 "type": "string"
                                             },
                                             "markdownDescription": "List of fingerprints corresponding to the keys to be added"
+                                        },
+                                        "when": {
+                                            "$ref": "#/definitions/stepWhen"
                                         }
                                     },
                                     "additionalProperties": false


### PR DESCRIPTION


# Description

Follow-up PR for https://github.com/CircleCI-Public/circleci-yaml-language-server/pull/453

Adds definitions.stepWhen and points every built-in step at it, so the step-level when attribute is accepted on checkout, setup_remote_docker, add_ssh_keys and both restore_cache forms, which still reported 'Additional property when is not allowed'.

# Implementation details

- add new definition in `schema.json` for a re-usable step-level when
- adds some tests within go to validate happy path and sad-path cases of this

# How to validate

Video proof! Otherwise the tests are passing in CI 

https://github.com/user-attachments/assets/885eb6c0-7f34-43ed-8a70-63b0616ec073


