### PR TITLE
ci: remove race condition between Github release and next release-please PR

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -372,7 +372,7 @@ jobs:
           name: Lint PR title
           command: gh pr view --json title --jq .title | npx commitlint
 
-  Prepare release:
+  Prepare next release PR:
     docker:
       - image: cimg/node:lts
     steps:
@@ -502,7 +502,7 @@ jobs:
           project: "${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}"
 
 workflows:
-  Release PR:
+  Build and prerelease:
     when: &release-conditions
       or:
         - equal:
@@ -511,14 +511,6 @@ workflows:
         - matches:
             value: << pipeline.git.branch >>
             pattern: ^hotfix.*$
-    jobs:
-      - Prepare release:
-          name: Create/update release PR
-          context:
-            - devex-release
-
-  Build and prerelease:
-    when: *release-conditions
     jobs:
       - Unit Tests
       - Security Scan release:
@@ -635,6 +627,12 @@ workflows:
       - Upload artifacts:
           requires:
             - Github Release
+          context:
+            - devex-release
+      - Prepare next release PR:
+          name: Create/update release PR
+          requires:
+            - Upload artifacts
           context:
             - devex-release
 


### PR DESCRIPTION






# Description

We ran into an issue where a new release (0.38.0) was merged. This kicked off two parallel workflows. One which creates the GitHub release, the other which creates / updates the release-please PR.

In this case the release-please PR creation workflow started first. It expected to find 0.38.0 in releases. It did not because the other parallel workflow hadn't created it yet. As a result, it re-created all the past changelog in the release PR as a new 0.39.0 release https://github.com/CircleCI-Public/circleci-yaml-language-server/pull/464


https://app.circleci.com/pipelines/gh/CircleCI-Public/circleci-yaml-language-server/2018/details?useNewPipelines=true&workflowId=735b56ba-1086-443c-9f32-fa000e225910&job=94650e97-fdfc-46bd-b296-108f8b17ce78&buildNumber=13382&jobType=build#step-101-

```
⚠ Expected 1 releases, only found 0
⚠ Missing 1 paths: .
❯ looking for tagName: 0.38.0
⚠ Expected 1 releases, only found 0
```

Release 0.38.0 was created right after this.

# Implementation details

- remove the individual workflow for creating a release PR
- move it into the other release workflow and put the job to make the PR AFTER the job to do the Github release

# How to validate

- make a new release and see how it goes

